### PR TITLE
start bot from CLI

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -50,6 +50,16 @@
       (-> f slurp read-string)
       {})))
 
+(deftask start []
+  (comp (environ :env config)
+        (with-pre-wrap fs
+          (require 'oc.bot 'com.stuartsierra.component)
+          ((resolve 'com.stuartsierra.component/start)
+           ((resolve 'oc.bot/system) {:sqs-queue       (:aws-sqs-queue config)
+                                      :sqs-msg-handler (resolve 'oc.bot/sqs-handler)}))
+          fs)
+        (wait)))
+
 (deftask dev []
   (comp (environ :env config)
         (repl)))


### PR DESCRIPTION
[trello card](https://trello.com/c/hjqDRhMJ/485-terminal-start-for-bot-in-addition-to-from-the-repl)

To test

- [ ] start bot with `boot start` — do things work as expected?