### PR TITLE
Company logo from Slack if present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.edn
 .nrepl-history
+.nrepl-port

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2015-2016 OpenCompany, Inc.
+Copyright © 2016 OpenCompany, LLC.
 
 Mozilla Public License, version 2.0
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Roadmap on Trello](http://img.shields.io/badge/roadmap-trello-blue.svg?style=flat)](https://trello.com/b/3naVWHgZ/open-company-development)
 
 
-## Overview
+## Background
 
 > Today, power is gained by sharing knowledge, not hoarding it.
 
@@ -21,14 +21,17 @@ To maintain transparency, OpenCompany information is always accessible and easy 
 
 Transparency expectations are changing. Startups need to change as well if they are going to attract and retain savvy employees and investors. Just as open source changed the way we build software, transparency changes how we build successful startups with information that is open, interactive, and always accessible. The OpenCompany platform turns transparency into a competitive advantage.
 
-Like the open companies we promote and support, the [OpenCompany](https://opencompany.com/) platform is completely transparent. The company supporting this effort, OpenCompany, Inc., is an open company. The [platform](https://github.com/open-company/open-company-web) is open source software, and open company data is [open data](https://en.wikipedia.org/wiki/Open_data) accessible through the [platform API](https://github.com/open-company/open-company-api).
+Like the open companies we promote and support, the [OpenCompany](https://opencompany.com/) platform is completely transparent. The company supporting this effort, OpenCompany, LLC, is an open company. The [platform](https://github.com/open-company/open-company-web) is open source software, and open company data is [open data](https://en.wikipedia.org/wiki/Open_data) accessible through the [platform API](https://github.com/open-company/open-company-api).
 
 To get started, head to: [OpenCompany](https://opencompany.com/)
 
 
-## Introduction
+## Overview
 
-Users of the [OpenCompany](https://opencompany.com/) platform should get started by going to [OpenCompany](https://opencompany.com/). The following is for developers wanting to work on the platform's Slack bot software.
+The OpenCompany Bot handles interacting with OpenCompany users via Slack conversations.
+
+
+## Introduction
 
 All use cases currently covered by this bot program involve some trigger from the outside world (which is currently done via AWS SQS).
 
@@ -49,8 +52,6 @@ Let’s go through the lifecycle of a *scripted conversation* step-by-step.
 3. If a message **fails** to advance the state of the FSM a generic “I don’t understand” message is sent back to the user.
 4. If a message **succeeds** to advance the FSM the appropriate response is looked up using the `stage` of the FSM as well as the meaning of the user’s message. The response is then sent to the `SlackConnection`.
 5. This process might loop until the conversation’s FSM reaches an accept state in which case it should be removed from the `ConversationManager` (TBD).
-
-## For Your Orientation
 
 #### Namespaces
 
@@ -87,7 +88,7 @@ Generic stuff that is not tied to any particular domain.
 
 **Testing Streams:** A lot of stuff is going through streams. Coming up with a proper testing setup for this is important. 
 
-## Authoring Scripts
+#### Authoring Scripts
 
 Scripts define the messages a bot will send when initiating a conversation or reacting to a user's messages.
 
@@ -129,9 +130,51 @@ Now the empty lists after these `[stage transition-signal]` pairs can be filled 
 
 ## Local Setup
 
-> Make sure you have Boot and Java 8 installed. For details refer [here](https://github.com/open-company/open-company-web#local-setup).
+Users of the [OpenCompany](https://opencompany.com/) platform should get started by going to [OpenCompany](https://opencompany.com/). The following local setup is **for developers** wanting to work on the platform's Bot software.
+
+Most of the dependencies are internal, meaning [Boot](https://github.com/boot-clj/boot) will handle getting them for you. There are a few exceptions:
+
+* [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) - a Java 8 JRE is needed to run Clojure
+* [Boot](https://github.com/boot-clj/boot) - A Clojure build and dependency management tool
+
+#### Java
+
+Chances are your system already has Java 8+ installed. You can verify this with:
+
+```console
+java -version
+```
+
+If you do not have Java 8+ [download it](http://www.oracle.com/technetwork/java/javase/downloads/index.html) and follow the installation instructions.
+
+#### Boot
+
+Installing Boot is easy, for the most up to date instructions, check out the [Boot README](https://github.com/boot-clj/boot#install).
+You can verify your install with:
+
+```console
+boot -V
+```
+
+#### Required Configuration and Secrets
+
+An [AWS SQS queue](https://aws.amazon.com/sqs/) is used to pass messages to the Bot. Setup an SQS Queue and key/secret access to the queue using the AWS Web Console or API.
+
+The Bot needs access to the OpenCompany API endpoint to make updates to open company content and data based on Bot conversations. 
 
 Before running anything make sure you copy `config.edn.template` to `config.edn` and adjust the values in the contained map.
+
+```clojure
+{
+  :aws-access-key-id "CHANGE-ME"
+  :aws-secret-access-key "CHANGE-ME"
+  :aws-sqs-queue "https://sqs.REGION.amazonaws.com/CHANGE/ME"
+
+  :oc-api-endpoint "http://localhost:3000"
+}
+```
+
+You can also override these settings with environmental variables in the form of `AWS_ACCESS_KEY_ID`, etc. Use environmental variables to provide production secrets when running in production.
 
 
 ## Usage
@@ -160,8 +203,9 @@ boot test!
 
 Please note that this project is released with a [Contributor Code of Conduct](https://github.com/open-company/open-company-web/blob/mainline/CODE-OF-CONDUCT.md). By participating in this project you agree to abide by its terms.
 
+
 ## License
 
 Distributed under the [Mozilla Public License v2.0](http://www.mozilla.org/MPL/2.0/). See `LICENSE` for full text.
 
-Copyright © 2015-2016 OpenCompany, Inc.
+Copyright © 2016 OpenCompany, LLC.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Messages sent to users need to be formatted, they need to be parameterised and t
 **oc.bot.conversation**
 This is responsible for all the state management inside conversations as well as for all message routing from Slack to individual conversations.
 
-**oc.bot.conversation.fsm**
+**oc.bot.fsm**
 Defines all the state machines that make up conversations and a few helpers related to these.
 
 **oc.bot.slack**

--- a/build.boot
+++ b/build.boot
@@ -21,6 +21,9 @@
                  ;; Asynchronous communication for clojure (http-client)
                  ;; https://github.com/ztellman/aleph
                  [aleph "0.4.2-alpha4"]
+                 ;; Apache Commons Validator provides the building blocks for validation.
+                 ;; https://commons.apache.org/proper/commons-validator/
+                 [commons-validator "1.5.1"]
                  ;; Async programming tools (streams/deferred computation)
                  ;; https://github.com/ztellman/manifold
                  [manifold "0.1.5-alpha1"]

--- a/build.boot
+++ b/build.boot
@@ -8,7 +8,7 @@
                  [com.stuartsierra/component "0.3.1"]
                  ;; Pure Clojure/Script logging library
                  ;; https://github.com/ptaoussanis/timbre
-                 [com.taoensso/timbre "4.5.0-RC2"]
+                 [com.taoensso/timbre "4.5.0-RC4"]
                  ;; Interface to Sentry error reporting
                  ;; https://github.com/sethtrain/raven-clj
                  [raven-clj "1.4.2"]
@@ -32,7 +32,7 @@
                  [automat "0.2.0-alpha2"]
                  ;; JSON encoding/decoding
                  ;; https://github.com/dakrone/cheshire
-                 [cheshire "5.6.1"]
+                 [cheshire "5.6.2"]
                  ;; Lightweight utility library
                  ;; https://github.com/weavejester/medley
                  [medley "0.8.2"]

--- a/config.edn.template
+++ b/config.edn.template
@@ -1,9 +1,7 @@
-{:aws-access-key-id "..."
- :aws-secret-access-key "..."
- :aws-sqs-queue "https://sqs.REGION.amazonaws.com/.../my-queue"
+{
+  :aws-access-key-id "CHANGE-ME"
+  :aws-secret-access-key "CHANGE-ME"
+  :aws-sqs-queue "https://sqs.REGION.amazonaws.com/CHANGE/ME"
 
- :oc-api-endpoint "http://localhost:3000"
-
- :slack-client-id "..."
- :slack-bot-token "xoxb-..."
- :slack-scopes [:bot :users:read]}
+  :oc-api-endpoint "http://localhost:3000"
+}

--- a/resources/scripts/onboard.edn
+++ b/resources/scripts/onboard.edn
@@ -10,15 +10,15 @@
  ["OK, I'll update the logo to this: {{company/logo}} Looks right? You can answer with *yes* or *no*."]
  [:company/logo :not-now]
  ["OK, you can always update the logo later at: {{env/origin}}/{{company/slug}}/profile"
-  "Good work {{user/name}}, your new OpenCompany dashboard is ready at: {{env/origin}}/{{company/slug}}"
+  "Your new OpenCompany dashboard is ready at: {{env/origin}}/{{company/slug}}"
   "Now it’ll be easier to keep your team, investors and other stakeholders engaged and up to date."]
  [:company/logo :yes-after-update]
  ["Cool, got it."
   "Good work {{user/name}}, your new OpenCompany dashboard is ready at: {{env/origin}}/{{company/slug}}"
-  "You may need to refresh your dashboard to see your new logo."
+  "(You may need to refresh your dashboard to see the correct logo.)"
   "Now it’ll be easier to keep your team, investors and other stakeholders engaged and up to date."]
  [:company/logo :yes]
  ["Great. We'll keep the image as is."
-  "Good work {{user/name}}, your new OpenCompany dashboard is ready at: {{env/origin}}/{{company/slug}}"
+  "Your new OpenCompany dashboard is ready at: {{env/origin}}/{{company/slug}}"
   "Now it’ll be easier to keep your team, investors and other stakeholders engaged and up to date."]
 }

--- a/resources/scripts/onboard.edn
+++ b/resources/scripts/onboard.edn
@@ -2,18 +2,20 @@
  ["Hi {{user/name}}, I’m the Slack bot for your OpenCompany dashboard."
   "I’ll help you share information about the company to keep everyone engaged and on the same page."
   "The first thing we ought to do is confirm the information OpenCompany has about {{company/name}}."
-  "{{#company/logo}}Is the following logo correct? You can answer with *yes* or *no*. {{company/logo}}{{/company/logo}}"
-  "{{^company/logo}}We don't yet have an logo to display on your company's dashboard. *Provide a link* or reply with *later*{{/company/logo}}"]
+  "{{#company/logo}}Is this the right logo for the company? You can answer with *yes* or *no*. {{company/logo}}{{/company/logo}}"
+  "{{^company/logo}}We don't yet have an logo to display on your company's dashboard. *Provide a link* (square works best) or reply with *later*{{/company/logo}}"]
  [:company/logo :no]
- ["Understood. What logo should I use? (please provide a link)"]
+ ["Understood. What logo should I use? The best dashboard logos fit into a square, roughly 180 x 180 pixels, like what you'd use for a Twitter avatar. You can answer with a URL (e.g. http://acme.com/logo.png). You can also answer with *later*."]
  [:company/logo :not-now]
- ["OK, sure. You can always go to your dashboard to change the logo."]
+ ["OK, you can always update the logo later at: {{env/origin}}/{{company/slug}}/profile"]
  [:company/logo :image-url]
- ["OK, I'll update the logo to {{company/logo}}. Sound right?"]
+ ["OK, I'll update the logo to this: {{company/logo}}. Looks right?"]
  [:company/logo :yes-after-update]
- ["Cool, got it."]
+ ["Cool, got it."
+  "Good work {{user/name}}, your new OpenCompany dashboard is ready at {{env/origin}}/{{company/slug}}! Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
  [:company/logo :yes]
- ["Great. We'll keep the image as is."]
+ ["Great. We'll keep the image as is."
+  "Good work {{user/name}}, your new OpenCompany dashboard is ready at {{env/origin}}/{{company/slug}}! Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
 
  ;; [:company/description :no]
  ;; ["Ok. You can always go to your dashboard later and add a description."

--- a/resources/scripts/onboard.edn
+++ b/resources/scripts/onboard.edn
@@ -2,15 +2,18 @@
  ["Hi {{user/name}}, I’m the Slack bot for your OpenCompany dashboard."
   "I’ll help you share information about the company to keep everyone engaged and on the same page."
   "The first thing we ought to do is confirm the information OpenCompany has about {{company/name}}."
-  "Is the following logo correct? You can answer with *yes* or *no*. {{company/logo}}"]
+  "{{#company/logo}}Is the following logo correct? You can answer with *yes* or *no*.{{company/logo}}{{/company/logo}}"
+  "{{^company/logo}}We don't yet have an logo to display on your company's dashboard. Provide a link or reply with *later*?{{/company/logo}}"]
  [:company/logo :no]
  ["Understood. What logo should I use? (please provide a link)"]
+ [:company/logo :not-now]
+ ["OK, sure. You can always go to your dashboard to change the logo."]
  [:company/logo :image-url]
  ["OK, I'll update the logo to {{company/logo}}. Sound right?"]
  [:company/logo :yes-after-update]
  ["Cool, got it."]
  [:company/logo :yes]
- ["Great."]
+ ["Great. We'll keep the image as is."]
 
  ;; [:company/description :no]
  ;; ["Ok. You can always go to your dashboard later and add a description."

--- a/resources/scripts/onboard.edn
+++ b/resources/scripts/onboard.edn
@@ -1,8 +1,8 @@
 {[:company/logo :init]
- ["Hi {{user/name}}, I’m the Slack bot for your OpenCompany dashboard."
-  "I’ll help you share information about the company to keep everyone engaged and on the same page."
+ ["Hi {{user/name}}, I’m the bot for your OpenCompany dashboard."
+  "I’ll help you share information about {{company/name}} to keep everyone engaged and on the same page."
   "The first thing we ought to do is confirm the information OpenCompany has about {{company/name}}."
-  "{{#company/logo}}Is this the right logo for the company? You can answer with *yes* or *no*. {{company/logo}}{{/company/logo}}"
+  "{{#company/logo}}Is this the right logo for {{company/name}}? You can answer with *yes* or *no*. {{company/logo}}{{/company/logo}}"
   "{{^company/logo}}We don't yet have an logo to display on your company's dashboard. *Provide a link* (square works best) or reply with *later*{{/company/logo}}"]
  [:company/logo :no]
  ["Understood. What logo should I use? The best dashboard logos fit into a square, roughly 180 x 180 pixels, like what you'd use for a Twitter avatar. You can answer with a URL (e.g. http://acme.com/logo.png). You can also answer with *later*."]
@@ -10,11 +10,14 @@
  ["OK, I'll update the logo to this: {{company/logo}} Looks right? You can answer with *yes* or *no*."]
  [:company/logo :not-now]
  ["OK, you can always update the logo later at: {{env/origin}}/{{company/slug}}/profile"
-  "Good work {{user/name}}, your new OpenCompany dashboard is ready at {{env/origin}}/{{company/slug}}! Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
+  "Good work {{user/name}}, your new OpenCompany dashboard is ready at: {{env/origin}}/{{company/slug}}"
+  "Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
  [:company/logo :yes-after-update]
  ["Cool, got it."
-  "Good work {{user/name}}, your new OpenCompany dashboard is ready at {{env/origin}}/{{company/slug}}! Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
+  "Good work {{user/name}}, your new OpenCompany dashboard is ready at: {{env/origin}}/{{company/slug}} You may need to refresh your dashboard to see your new logo."
+  "Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
  [:company/logo :yes]
  ["Great. We'll keep the image as is."
-  "Good work {{user/name}}, your new OpenCompany dashboard is ready at {{env/origin}}/{{company/slug}}! Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
+  "Good work {{user/name}}, your new OpenCompany dashboard is ready at: {{env/origin}}/{{company/slug}}"
+  "Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
 }

--- a/resources/scripts/onboard.edn
+++ b/resources/scripts/onboard.edn
@@ -4,8 +4,8 @@
   "The first thing we ought to do is confirm the information OpenCompany has about {{company/name}}."
   "Is the following logo correct? You can answer with *yes* or *no*. {{company/logo}}"]
  [:company/logo :no]
- ["Understood. What name should I use?"]
- [:company/logo :image]
+ ["Understood. What logo should I use? (please provide a link)"]
+ [:company/logo :image-url]
  ["OK, I'll update the logo to {{company/logo}}. Sound right?"]
  [:company/logo :yes-after-update]
  ["Cool, got it."]

--- a/resources/scripts/onboard.edn
+++ b/resources/scripts/onboard.edn
@@ -1,15 +1,15 @@
-{[:company/name :init]
+{[:company/logo :init]
  ["Hi {{user/name}}, I’m the Slack bot for your OpenCompany dashboard."
   "I’ll help you share information about the company to keep everyone engaged and on the same page."
   "The first thing we ought to do is confirm the information OpenCompany has about {{company/name}}."
-  "Is “{{company/name}}” the right name for the company? You can answer with *yes* or *no*."]
- [:company/name :no]
+  "Is the following logo correct? You can answer with *yes* or *no*. {{company/logo}}"]
+ [:company/logo :no]
  ["Understood. What name should I use?"]
- [:company/name :str]
- ["OK, I'll update the company name to {{company/name}}. Sound right?"]
- [:company/name :yes-after-update]
+ [:company/logo :image]
+ ["OK, I'll update the logo to {{company/logo}}. Sound right?"]
+ [:company/logo :yes-after-update]
  ["Cool, got it."]
- [:company/name :yes]
+ [:company/logo :yes]
  ["Great."]
 
  ;; [:company/description :no]

--- a/resources/scripts/onboard.edn
+++ b/resources/scripts/onboard.edn
@@ -11,13 +11,14 @@
  [:company/logo :not-now]
  ["OK, you can always update the logo later at: {{env/origin}}/{{company/slug}}/profile"
   "Good work {{user/name}}, your new OpenCompany dashboard is ready at: {{env/origin}}/{{company/slug}}"
-  "Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
+  "Now it’ll be easier to keep your team, investors and other stakeholders engaged and up to date."]
  [:company/logo :yes-after-update]
  ["Cool, got it."
-  "Good work {{user/name}}, your new OpenCompany dashboard is ready at: {{env/origin}}/{{company/slug}} You may need to refresh your dashboard to see your new logo."
-  "Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
+  "Good work {{user/name}}, your new OpenCompany dashboard is ready at: {{env/origin}}/{{company/slug}}"
+  "You may need to refresh your dashboard to see your new logo."
+  "Now it’ll be easier to keep your team, investors and other stakeholders engaged and up to date."]
  [:company/logo :yes]
  ["Great. We'll keep the image as is."
   "Good work {{user/name}}, your new OpenCompany dashboard is ready at: {{env/origin}}/{{company/slug}}"
-  "Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
+  "Now it’ll be easier to keep your team, investors and other stakeholders engaged and up to date."]
 }

--- a/resources/scripts/onboard.edn
+++ b/resources/scripts/onboard.edn
@@ -2,8 +2,8 @@
  ["Hi {{user/name}}, I’m the Slack bot for your OpenCompany dashboard."
   "I’ll help you share information about the company to keep everyone engaged and on the same page."
   "The first thing we ought to do is confirm the information OpenCompany has about {{company/name}}."
-  "{{#company/logo}}Is the following logo correct? You can answer with *yes* or *no*.{{company/logo}}{{/company/logo}}"
-  "{{^company/logo}}We don't yet have an logo to display on your company's dashboard. Provide a link or reply with *later*?{{/company/logo}}"]
+  "{{#company/logo}}Is the following logo correct? You can answer with *yes* or *no*. {{company/logo}}{{/company/logo}}"
+  "{{^company/logo}}We don't yet have an logo to display on your company's dashboard. *Provide a link* or reply with *later*{{/company/logo}}"]
  [:company/logo :no]
  ["Understood. What logo should I use? (please provide a link)"]
  [:company/logo :not-now]

--- a/resources/scripts/onboard.edn
+++ b/resources/scripts/onboard.edn
@@ -6,10 +6,11 @@
   "{{^company/logo}}We don't yet have an logo to display on your company's dashboard. *Provide a link* (square works best) or reply with *later*{{/company/logo}}"]
  [:company/logo :no]
  ["Understood. What logo should I use? The best dashboard logos fit into a square, roughly 180 x 180 pixels, like what you'd use for a Twitter avatar. You can answer with a URL (e.g. http://acme.com/logo.png). You can also answer with *later*."]
- [:company/logo :not-now]
- ["OK, you can always update the logo later at: {{env/origin}}/{{company/slug}}/profile"]
  [:company/logo :image-url]
  ["OK, I'll update the logo to this: {{company/logo}}. Looks right?"]
+ [:company/logo :not-now]
+ ["OK, you can always update the logo later at: {{env/origin}}/{{company/slug}}/profile"
+  "Good work {{user/name}}, your new OpenCompany dashboard is ready at {{env/origin}}/{{company/slug}}! Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
  [:company/logo :yes-after-update]
  ["Cool, got it."
   "Good work {{user/name}}, your new OpenCompany dashboard is ready at {{env/origin}}/{{company/slug}}! Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]

--- a/resources/scripts/onboard.edn
+++ b/resources/scripts/onboard.edn
@@ -7,7 +7,7 @@
  [:company/logo :no]
  ["Understood. What logo should I use? The best dashboard logos fit into a square, roughly 180 x 180 pixels, like what you'd use for a Twitter avatar. You can answer with a URL (e.g. http://acme.com/logo.png). You can also answer with *later*."]
  [:company/logo :image-url]
- ["OK, I'll update the logo to this: {{company/logo}}. Looks right?"]
+ ["OK, I'll update the logo to this: {{company/logo}} Looks right? You can answer with *yes* or *no*."]
  [:company/logo :not-now]
  ["OK, you can always update the logo later at: {{env/origin}}/{{company/slug}}/profile"
   "Good work {{user/name}}, your new OpenCompany dashboard is ready at {{env/origin}}/{{company/slug}}! Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
@@ -17,49 +17,4 @@
  [:company/logo :yes]
  ["Great. We'll keep the image as is."
   "Good work {{user/name}}, your new OpenCompany dashboard is ready at {{env/origin}}/{{company/slug}}! Now it’s easy to keep your team, investors and other stakeholders engaged and up to date."]
-
- ;; [:company/description :no]
- ;; ["Ok. You can always go to your dashboard later and add a description."
- ;;  "Good work {{user/name}}, your new company dashboard is ready at https://opencompany.com/{{company/slug}}!"
- ;;  "You’ll find a few common topics are already in your dashboard to give you a head start, but it’s easy to pick the ones you want. As information is updated in your dashboard, I’ll let everyone know via Slack."
- ;;  "Just visit https://opencompany.com/{{company/slug}} to get started!"]
- ;; [:company/description :str]
- ;; ["Nice. The description will be updated to “{{company/description}}”, sound right?"]
- ;; [:company/description :yes-after-update]
- ;; ["Ok, I've updated the description."
- ;;  "Good work {{user/name}}, your new company dashboard is ready at https://opencompany.com/{{company/slug}}!"
- ;;  "You’ll find a few common topics are already in your dashboard to give you a head start, but it’s easy to pick the ones you want. As information is updated in your dashboard, I’ll let everyone know via Slack."
- ;;  "Just visit https://opencompany.com/{{company/slug}} to get started!"]
-
- ;; [:company/currency :no]
- ;; ["OK. What’s the right currency for {{company/name}}?"]
- ;; [:company/currency :currency]
- ;; ["OK. The currency will be updated to “{{company/currency}}”, sound right?"]
- ;; [:company/currency :yes-after-update]
- ;; ["Great, I updated the currency to “{{company/currency}}”"
- ;;  "Good work {{user/name}}, we’re done setting up {{company/name}}. You can revisit these settings at anytime here: https://opencompany.com/{{company/slug}}/settings  or message me with “settings”."
- ;;  "{{company/name}} now has a company transparency dashboard with a set of core topics: Founder’s Update, Growth, Key Challenges, Team and Hiring, Product, Finances, Values, and Mission."
- ;;  "You should visit the dashboard now and start updating the information so all {{company/name}} stakeholders have easy access to up to date information: https://opencompany.com/{{company/slug}}"
- ;;  "You can also add or remove topics to better reflect the information your company stakeholders need."
- ;;  "If some of your fellow colleagues are better sources of some of this core company information, please send them a Slack message and ask them to visit the dashboard and update the information."
- ;;  "Once a month we’ll send a stakeholder update to all internal stakeholders (members of this Slack organization) and to any external stakeholders you identify such as investors and advisors."
- ;;  "Are you the CEO or the person that should be responsible for approving the stakeholder update? You can answer with *yes* or *no*."]
- ;; [:company/currency :yes]
- ;; ["Great."
- ;;  "Good work {{user/name}}, we’re done setting up {{company/name}}. You can revisit these settings at anytime here: https://opencompany.com/{{company/slug}}/settings  or message me with “settings”."
- ;;  "{{company/name}} now has a company transparency dashboard with a set of core topics: Founder’s Update, Growth, Key Challenges, Team and Hiring, Product, Finances, Values, and Mission."
- ;;  "You should visit the dashboard now and start updating the information so all {{company/name}} stakeholders have easy access to up to date information: https://opencompany.com/{{company/slug}}"
- ;;  "You can also add or remove topics to better reflect the information your company stakeholders need."
- ;;  "If some of your fellow colleagues are better sources of some of this core company information, please send them a Slack message and ask them to visit the dashboard and update the information."
- ;;  "Once a month we’ll send a stakeholder update to all internal stakeholders (members of this Slack organization) and to any external stakeholders you identify such as investors and advisors."
- ;;  "Are you the CEO or the person that should be responsible for approving the stakeholder update? You can answer with *yes* or *no*."]
-
- ;; [:ceo :no]
- ;; ["OK, who is the CEO or the person that should be responsible for approving the stakeholder update? You can just type in their Slack name (eg. @johndoe)."]
- ;; [:ceo :str]
- ;; ["OK, so {{ceo}} should be responsible for approving the stakeholder update? You can answer with *yes* or *no*."]
- ;; [:ceo :yes-after-update]
- ;; ["Great. Thanks {{user/name}}."]
- ;; [:ceo :yes]
- ;; ["OK. Let's configure who receives Stakeholder updates then."]
- }
+}

--- a/src/oc/bot.clj
+++ b/src/oc/bot.clj
@@ -9,6 +9,7 @@
             [oc.sentry-appender :as sentry]
             [oc.bot.sqs :as sqs]
             [oc.bot.slack :as slack]
+            [oc.bot.slack-api :as slack-api]
             [oc.bot.conversation :as conv]
             [oc.bot.message :as msg])
   (:gen-class))
@@ -40,13 +41,13 @@
     (timbre/info "Adjusting receiver" {:type type})
     (cond
       (and (= :user type) (= \U (-> msg :receiver :id first)))
-      [(assoc msg :receiver {:id (slack/get-im-channel token (-> msg :receiver :id))
+      [(assoc msg :receiver {:id (slack-api/get-im-channel token (-> msg :receiver :id))
                              :type :channel})]
 
       (and (= :all-members type))
-      (for [u (filter real-user? (slack/get-users token))]
+      (for [u (filter real-user? (slack-api/get-users token))]
         (-> (assoc-in msg [:script :params :user/name] (first-name (:real_name u)))
-            (assoc :receiver {:type :channel :id (slack/get-im-channel token (:id u))})))
+            (assoc :receiver {:type :channel :id (slack-api/get-im-channel token (:id u))})))
 
       :else
       (throw (ex-info "Failed to adjust receiver" {:msg msg})))))
@@ -135,13 +136,13 @@
   )
 
 (comment 
-  (def names (map :real_name (filter real-user? (slack/get-users tkn))))
+  (def names (map :real_name (filter real-user? (slack-api/get-users tkn))))
 
   (map first-name names)
 
-  (map :real_name (filter real-user? (slack/get-users tkn)))
+  (map :real_name (filter real-user? (slack-api/get-users tkn)))
 
-  (set (flatten (map :id (remove :deleted (slack/get-users tkn)))))
+  (set (flatten (map :id (remove :deleted (slack-api/get-users tkn)))))
 
   (adjust-receiver {:bot {:token tkn}
                     :receiver {:type :all-members}})

--- a/src/oc/bot.clj
+++ b/src/oc/bot.clj
@@ -112,11 +112,6 @@
        :receiver {:type :user :id ch-id}
        :bot      {:token (e/env :slack-bot-token) :id bot-user-id}}))
 
-  (aws-sqs/send-message sqs/creds (e/env :aws-sqs-queue) (test-onboard-trigger "Stuart" bot-testing-ch))
-
-  (aws-sqs/send-message sqs/creds (e/env :aws-sqs-queue) (test-onboard-trigger "Stuart" user-id))
-  (aws-sqs/send-message sqs/creds (e/env :aws-sqs-queue) (test-su-trigger "Martin" user-id))
-
   (test-onboard-trigger "Martin" user-id)
 
   (sqs-handler sys {:body (pr-str (test-onboard-trigger "Martin" user-id))})
@@ -127,6 +122,11 @@
   (alter-var-root #'sys component/start)
 
   (alter-var-root #'sys component/stop)
+
+  (aws-sqs/send-message sqs/creds (e/env :aws-sqs-queue) (test-onboard-trigger "Stuart" bot-testing-ch))
+
+  (aws-sqs/send-message sqs/creds (e/env :aws-sqs-queue) (test-onboard-trigger "Stuart" user-id))
+  (aws-sqs/send-message sqs/creds (e/env :aws-sqs-queue) (test-su-trigger "Martin" user-id))
 
   ;; Messages after bot got invited into channel
   {:type "channel_joined", :channel {:creator "U06SBTXJR", :purpose {:value "Discuss development of the OPENcompany platform", :creator "U06SBTXJR", :last_set 1454426238}, :is_channel true, :name "development", :is_member true, :is_archived false, :created 1448888630, :topic {:value "", :creator "", :last_set 0}, :latest {:type "message", :user "U0JSATHT3", :text "<@U06SBTXJR>: can you kick the bot out of <#C10A1P4H2> please?", :ts "1461337454.001157"}, :id "C0FGNSA2V", :unread_count_display 0, :last_read "1461337454.001157", :members ["U06SBTXJR" "U06SQLDFT" "U06STCKLN" "U0J5LK571" "U0JSATHT3" "U10AR0H50"], :is_general false, :unread_count 0}}

--- a/src/oc/bot.clj
+++ b/src/oc/bot.clj
@@ -1,7 +1,6 @@
 (ns oc.bot
   (:require [com.stuartsierra.component :as component]
             [amazonica.aws.sqs :as aws-sqs]
-            [clojure.java.io :as io]
             [clojure.string :as string]
             [environ.core :as e]
             [manifold.stream :as s]

--- a/src/oc/bot.clj
+++ b/src/oc/bot.clj
@@ -93,28 +93,32 @@
                                         :company/description "Save time managing your social media" :company/currency "USD"
                                         :contact-person "Tom"}}
        :api-token jwt
-       :receiver {:type :channel :id ch-id}
+       :receiver {:type :user :id ch-id}
        :bot      {:token (e/env :slack-bot-token) :id bot-user-id}})
     (defn test-su-trigger [name ch-id]
       {:diff     (rand-int 1000)
        :script   {:id :stakeholder-update :params {:user/name name :company/name "Buffer" :company/slug "buffer" :stakeholder-update/slug "abc" :stakeholder-update/note "We're profitable!!"}}
-       :receiver {:type :user :id ch-id}
+       :receiver {:type :all-members}
        :bot      {:token (e/env :slack-bot-token) :id bot-user-id}})
     (defn test-onboard-user-trigger [name ch-id]
       {:diff     (rand-int 1000)
        :script   {:id :onboard-user :params {:user/name name :company/name "Buffer" :company/slug "buffer" :contact-person "Jim"}}
-       :receiver {:type :channel :id ch-id}
+       :receiver {:type :user :id ch-id}
        :bot      {:token (e/env :slack-bot-token) :id bot-user-id}})
     (defn test-onboard-user-authenticated-trigger [name ch-id]
       {:diff     (rand-int 1000)
        :script   {:id :onboard-user-authenticated :params {:user/name name :company/name "Buffer" :company/slug "buffer"}}
-       :receiver {:type :channel :id ch-id}
+       :receiver {:type :user :id ch-id}
        :bot      {:token (e/env :slack-bot-token) :id bot-user-id}}))
 
   (aws-sqs/send-message sqs/creds (e/env :aws-sqs-queue) (test-onboard-trigger "Stuart" bot-testing-ch))
 
   (aws-sqs/send-message sqs/creds (e/env :aws-sqs-queue) (test-onboard-trigger "Stuart" user-id))
   (aws-sqs/send-message sqs/creds (e/env :aws-sqs-queue) (test-su-trigger "Martin" user-id))
+
+  (test-onboard-trigger "Martin" user-id)
+
+  (sqs-handler sys {:body (pr-str (test-onboard-trigger "Martin" user-id))})
 
   (def sys (system {:sqs-queue (e/env :aws-sqs-queue)
                     :sqs-msg-handler sqs-handler}))

--- a/src/oc/bot/.#language.clj
+++ b/src/oc/bot/.#language.clj
@@ -1,1 +1,0 @@
-martin@MacBook-Air-3.local.21053

--- a/src/oc/bot/.#language.clj
+++ b/src/oc/bot/.#language.clj
@@ -1,0 +1,1 @@
+martin@MacBook-Air-3.local.21053

--- a/src/oc/bot/conversation.clj
+++ b/src/oc/bot/conversation.clj
@@ -132,6 +132,53 @@
      :init-msg  init-msg
      :stages    (-> scripts script-id :stages)}))
 
+(defn -transition-init
+  [fsm-atom out-stream msg]
+  ;; Startup case, i.e. messages coming from SQS initiating new convs ========
+  (let [->full-msg (fn [text] {:type "message" :text text :channel (-> msg :receiver :id)})
+        script-id  (-> msg :script :id)
+        transition [:init]
+        new-fsm    (a/advance (get-in scripts [script-id :fsm])
+                              (init-state msg)
+                              transition)]
+    (timbre/info "Starting new scripted conversation:" script-id)
+    (reset! fsm-atom new-fsm)
+    (doseq [m' (messages (:value new-fsm) transition)]
+      (s/put! out-stream (->full-msg m')))
+    (d/success-deferred true))) ; use `drain-into` coming in manifold 0.1.5
+
+(defn -transition-msg
+  [fsm-atom out-stream msg]
+  (let [->full-msg   (fn [text] {:type "message" :text text :channel (:channel msg)})
+        compiled-fsm (get-in scripts [(-> @fsm-atom :value :script-id) :fsm])
+        allowed?     (fsm/possible-transitions compiled-fsm @fsm-atom)
+        transition   (msg-text->transition (:text msg) allowed?)]
+    (timbre/info "Transitioning" {:message msg :transition transition})
+    (let [updated-fsm  (a/advance compiled-fsm @fsm-atom transition ::invalid)]
+      ;; Side effects
+      (if (= ::invalid updated-fsm)
+        (do
+          (timbre/info "Message could not be turned into allowed signal"
+                       {:allowed? allowed?
+                        :fsm-state @fsm-atom
+                        :msg msg
+                        :transition transition})
+          (s/put! out-stream (->full-msg (str "Sorry, " (-> @fsm-atom :value :init-msg :script :params :user/name)
+                                              ". I'm not sure what to do with this.")))
+          (if-let [guide-msg (not-understood (first allowed?))]
+            (s/put! out-stream (->full-msg guide-msg)))
+          (d/success-deferred true)) ; use `drain-into` coming in manifold 0.1.5
+        (do
+          (if (and (stage-confirmed? updated-fsm)
+                   (not (:accepted? updated-fsm)))
+            (reset! fsm-atom (a/advance compiled-fsm updated-fsm [:next-stage]))
+            (reset! fsm-atom updated-fsm))
+          (if (:error (:value updated-fsm))
+            (s/put! out-stream (->full-msg "Sorry, something broke. We're on it. Please try again later."))
+            (doseq [m' (messages (:value updated-fsm) transition)]
+              (s/put! out-stream (->full-msg m'))))
+          (d/success-deferred true)))))); use `drain-into` coming in manifold 0.1.5
+
 (defn transition-fn
   "Inputs:
    - `fsm-atom`, Atom containing the current state of the FSM representing the conversation
@@ -151,49 +198,8 @@
   it's state will be updated to be in the next stage."
   [fsm-atom out-stream msg]
   (if (initialize? msg)
-    ;; Startup case, i.e. messages coming from SQS initiating new convs ========
-    (let [->full-msg (fn [text] {:type "message" :text text :channel (-> msg :receiver :id)})
-          script-id  (-> msg :script :id)
-          transition [:init]
-          new-fsm    (a/advance (get-in scripts [script-id :fsm])
-                                (init-state msg)
-                                transition)]
-      (timbre/info "Starting new scripted conversation:" script-id)
-      (reset! fsm-atom new-fsm)
-      (doseq [m' (messages (:value new-fsm) transition)]
-        (s/put! out-stream (->full-msg m')))
-      (d/success-deferred true)) ; use `drain-into` coming in manifold 0.1.5
-
-    ;; Regular case, i.e. messages sent by users =============================
-    (let [->full-msg   (fn [text] {:type "message" :text text :channel (:channel msg)})
-          compiled-fsm (get-in scripts [(-> @fsm-atom :value :script-id) :fsm])
-          allowed?     (fsm/possible-transitions compiled-fsm @fsm-atom)
-          transition   (msg-text->transition (:text msg) allowed?)]
-      (timbre/info "Transitioning" {:message msg :transition transition})
-      (let [updated-fsm  (a/advance compiled-fsm @fsm-atom transition ::invalid)]
-        ;; Side effects
-        (if (= ::invalid updated-fsm)
-          (do
-            (timbre/info "Message could not be turned into allowed signal"
-                          {:allowed? allowed?
-                           :fsm-state @fsm-atom
-                           :msg msg
-                           :transition transition})
-            (s/put! out-stream (->full-msg (str "Sorry, " (-> @fsm-atom :value :init-msg :script :params :user/name)
-                                                ". I'm not sure what to do with this.")))
-            (if-let [guide-msg (not-understood (first allowed?))]
-              (s/put! out-stream (->full-msg guide-msg)))
-            (d/success-deferred true)) ; use `drain-into` coming in manifold 0.1.5
-          (do
-            (if (and (stage-confirmed? updated-fsm)
-                     (not (:accepted? updated-fsm)))
-              (reset! fsm-atom (a/advance compiled-fsm updated-fsm [:next-stage]))
-              (reset! fsm-atom updated-fsm))
-            (if (:error (:value updated-fsm))
-              (s/put! out-stream (->full-msg "Sorry, something broke. We're on it. Please try again later."))
-              (doseq [m' (messages (:value updated-fsm) transition)]
-                (s/put! out-stream (->full-msg m'))))
-            (d/success-deferred true))))))) ; use `drain-into` coming in manifold 0.1.5
+    (-transition-init fsm-atom out-stream msg) ; Startup case, i.e. messages coming from SQS initiating new convs
+    (-transition-msg fsm-atom out-stream msg))) ; Regular case, i.e. messages sent by users
 
 ;; -----------------------------------------------------------------------------
 ;; Conversation Routing 

--- a/src/oc/bot/conversation.clj
+++ b/src/oc/bot/conversation.clj
@@ -76,12 +76,12 @@
                 (-> msg :receiver :id))))
 
 (defn transitions [txt]
-  {lang/yes?     [:yes]
-   lang/no?      [:no]
-   lang/euro?    [:currency ::eur]
-   lang/dollar?  [:currency ::usd]
-   lang/downloadable-image? [:image-url txt]
-   (fn [_] true) [:str txt]})
+  {lang/yes?                [:yes]
+   lang/no?                 [:no]
+   lang/euro?               [:currency ::eur]
+   lang/dollar?             [:currency ::usd]
+   lang/downloadable-image? [:image-url (lang/extract-url txt)]
+   identity                 [:str txt]})
 
 (defn msg-text->transition
   "Given a users message `txt` and a set of `allowed?` signals

--- a/src/oc/bot/conversation.clj
+++ b/src/oc/bot/conversation.clj
@@ -163,7 +163,7 @@
                         :transition transition})
           (s/put! out-stream (->full-msg (str "Sorry, " (-> fsm-state :value :init-msg :script :params :user/name)
                                               ". I'm not sure what to do with this.")))
-          (if-let [guide-msg (not-understood (first allowed?))]
+          (if-let [guide-msg (first (keep not-understood allowed?))]
             (s/put! out-stream (->full-msg guide-msg)))
           (d/success-deferred true)) ; use `drain-into` coming in manifold 0.1.5
         (do

--- a/src/oc/bot/conversation.clj
+++ b/src/oc/bot/conversation.clj
@@ -29,7 +29,7 @@
    into `out` after sending a few 'typing' messages into out."
   [out]
   (fn [msg]
-    (let [wait-time (* 50 (count (:text msg)))
+    (let [wait-time (* 25 (count (:text msg)))
           typing    {:type "typing" :channel (:channel msg)}]
       (-> (apply d/chain
                  nil

--- a/src/oc/bot/conversation.clj
+++ b/src/oc/bot/conversation.clj
@@ -75,12 +75,6 @@
   (boolean (and (= :oc.bot/initialize (:type msg))
                 (-> msg :receiver :id))))
 
-(defn from-bot? [msg bot-uid]
-  (= bot-uid (:user msg)))
-
-(defn message? [msg]
-  (= "message" (:type msg)))
-
 (defn transitions [txt]
   {lang/yes?     [:yes]
    lang/no?      [:no]
@@ -202,8 +196,9 @@
   [base-msg]
   (when (initialize? base-msg)
     (fn [msg]
-      (and (not (from-bot? msg (-> base-msg :bot :id)))
-           (message? msg)
+      (and (not= (:subtype msg) "bot_message")
+           (not= (:user msg) (-> base-msg :bot :id))
+           (= (:type msg) "message")
            (= (:channel msg)
               (-> base-msg :receiver :id))))))
 

--- a/src/oc/bot/conversation.clj
+++ b/src/oc/bot/conversation.clj
@@ -7,8 +7,9 @@
             [automat.core :as a]
             [clojure.string :as string]
             [medley.core :as med]
-            [oc.bot.conversation.fsm :as fsm]
+            [oc.bot.fsm :as fsm]
             [oc.bot.message :as m]
+            [oc.bot.slack-api :as slack-api]
             [oc.bot.language :as lang]
             [oc.bot.utils :as u])
   (:import [java.time LocalDateTime]))

--- a/src/oc/bot/conversation.clj
+++ b/src/oc/bot/conversation.clj
@@ -199,8 +199,6 @@
     (-transition-init fsm-atom out-stream msg) ; Startup case, i.e. messages coming from SQS
     (-transition-msg fsm-atom out-stream msg))) ; Regular case, i.e. messages sent by users
 
-
-
 ;; -----------------------------------------------------------------------------
 ;; Conversation Routing 
 ;; Route messages to their respective conversations or create new conversations
@@ -212,6 +210,7 @@
   (when (initialize? base-msg)
     (fn [msg]
       (and (not= (:subtype msg) "bot_message")
+           (not= (:subtype msg) "message_changed")
            (not= (:user msg) (-> base-msg :bot :id))
            (= (:type msg) "message")
            (= (:channel msg)

--- a/src/oc/bot/conversation.clj
+++ b/src/oc/bot/conversation.clj
@@ -78,6 +78,7 @@
 (defn transitions [txt]
   {lang/yes?                [:yes]
    lang/no?                 [:no]
+   lang/not-now?            [:not-now]
    lang/euro?               [:currency ::eur]
    lang/dollar?             [:currency ::usd]
    lang/downloadable-image? [:image-url (lang/extract-url txt)]
@@ -118,7 +119,8 @@
 (def not-understood
   {:yes "You can answer with *yes* or *no*."
    :no "You can answer with *yes* or *no*."
-   :currency "You can provide a currency with *EUR* or *USD*."})
+   :currency "You can provide a currency with *EUR* or *USD*."
+   :image-url "Please provide a link to an image that is publicly accessibly."})
 
 (defn init-state [init-msg]
   (let [script-id (-> init-msg :script :id)

--- a/src/oc/bot/conversation.clj
+++ b/src/oc/bot/conversation.clj
@@ -85,6 +85,7 @@
    lang/no?      [:no]
    lang/euro?    [:currency ::eur]
    lang/dollar?  [:currency ::usd]
+   lang/downloadable-image? [:image-url txt]
    (fn [_] true) [:str txt]})
 
 (defn msg-text->transition

--- a/src/oc/bot/conversation.clj
+++ b/src/oc/bot/conversation.clj
@@ -204,8 +204,8 @@
 
 (defn find-matching-conv [convs msg]
   (let [[f s] (vec (u/predicate-map-lookup convs msg))]
-    (when s (timbre/debug "predicate-map-lookup returned multiple results, using first"))
-    (when f (timbre/debugf "predicate-match for: %s\n" msg))
+    (when s (timbre/warn "predicate-map-lookup returned multiple results, using first"))
+    (when f (timbre/debug "predicate-match for:" msg))
     f))
 
 (defn mk-conv [out]

--- a/src/oc/bot/conversation/fsm.clj
+++ b/src/oc/bot/conversation/fsm.clj
@@ -46,7 +46,7 @@
 
 (def onboard-fsm
   (a/compile [:init
-              (fact-check :str) ;name
+              (fact-check :image-url) ;logo
               [:next-stage (a/$ :next-stage)]]
              {:signal   first
               :reducers {:next-stage (dry-run-wrap (fn [state input] (update state :stage (fn [s] (u/next-in (:stages state) s)))))

--- a/src/oc/bot/fsm.clj
+++ b/src/oc/bot/fsm.clj
@@ -46,7 +46,9 @@
   (let [presence-branch? (= (possible-transitions compiled-fsm fsm-state)
                             #{::value-present ::value-missing})
         ;; TODO this could/should be passed to the function as a parameter
-        val-present?     (get-in value [:init-msg :script :params (-> value :stage)])]
+        val-present?     (-> (merge (get-in value [:init-msg :script :params])
+                                    (get-in value [:updated]))
+                             (get (-> value :stage)))]
     (cond
       (and presence-branch? val-present?) (a/advance compiled-fsm fsm-state [::value-present])
       (and presence-branch?)              (a/advance compiled-fsm fsm-state [::value-missing])

--- a/src/oc/bot/fsm.clj
+++ b/src/oc/bot/fsm.clj
@@ -67,7 +67,9 @@
 
 (def onboard-fsm
   (a/compile [:init
-              (fact-check :image-url) ;logo
+              ;; company/logo
+              (presence-branch (fact-check :image-url)
+                               (optional-input :image-url))
               [:next-stage (a/$ :next-stage)]]
              {:signal   first
               :reducers {:next-stage (dry-run-wrap (fn [state input] (update state :stage (fn [s] (u/next-in (:stages state) s)))))

--- a/src/oc/bot/fsm.clj
+++ b/src/oc/bot/fsm.clj
@@ -60,6 +60,13 @@
     [(a/+ [:no [update-transition (a/$ :update)]])
      [:yes (a/$ :confirm)]])])
 
+(defn skippable-fact-check [update-transition]
+  [(a/or
+    [:yes (a/$ :confirm)]
+    [:no :not-now]
+    [(a/+ [:no [update-transition (a/$ :update)]])
+     [:yes (a/$ :confirm)]])])
+
 (defn optional-input [update-transition]
   [(a/or [:not-now]
          [update-transition (a/$ :update)
@@ -70,7 +77,7 @@
 (def onboard-fsm
   (a/compile [:init
               ;; company/logo
-              (presence-branch (fact-check :image-url)
+              (presence-branch (skippable-fact-check :image-url)
                                (optional-input :image-url))
               [:next-stage (a/$ :next-stage)]]
              {:signal   first
@@ -102,7 +109,7 @@
   (require 'automat.viz)
 
   (automat.viz/view (fact-check :str))
-  (automat.viz/view (presence-branch (fact-check :image-url)
+  (automat.viz/view (presence-branch (skippable-fact-check :image-url)
                                      (optional-input :image-url)))
   
   )

--- a/src/oc/bot/fsm.clj
+++ b/src/oc/bot/fsm.clj
@@ -19,7 +19,7 @@
   (let [alphabet (f/alphabet (:fsm (meta compiled-fsm)))
         dry-run  (assoc-in state [:value ::dry-run] true)]
     ;; SIGNAL using [t] here means we assume the FSMs signal function is `first`
-    (-> #(do #_(timbre/debug "Testing transition" % "with state" dry-run)
+    (-> #(do ;(timbre/debug "Testing transition" % "with state" dry-run)
              (a/advance compiled-fsm dry-run [%] false))
         (filter alphabet)
         (set))))

--- a/src/oc/bot/language.clj
+++ b/src/oc/bot/language.clj
@@ -44,9 +44,9 @@
 
   (downloadable-image? "<https://logo.clearbit.com/pantheon.io?s=126>")
 
-  (valid-url "https://-R6qwnGcrHlY/AAAAAAAAAAI/AAAAAAAAAAA/SuoCUhq2DAM/w80-h80/photo.jpg")
+  (extract-url "https://-R6qwnGcrHlY/AAAAAAAAAAI/AAAAAAAAAAA/SuoCUhq2DAM/w80-h80/photo.jpg")
 
-  (valid-url "<https://threaded.martinklepsch.org/fav/apple-icon-152x152.png>")
+  (extract-url "<https://threaded.martinklepsch.org/fav/apple-icon-152x152.png>")
 
   (re-seq #"<(.*)>" "<https://threaded.martinklepsch.org/fav/apple-icon-152x152.png>")
 
@@ -54,7 +54,12 @@
 
   (downloadable-image? "<http://media.giphy.com/media/xTiTnlgsJTVPK9hGZa/giphy.gif>")
 
+  (downloadable-image? "<https://media.giphy.com/media/xTiTnlgsJTVPK9hGZa/giphy.gif>")
+
   (downloadable-image? "<https://pbs.twimg.com/profile_images/700577267127193600/PtLt3m6R.png>")
+  (downloadable-image? "<http://pbs.twimg.com/profile_images/700577267127193600/PtLt3m6R.png>")
+
+  (downloadable-image? "<https://bigoven-res.cloudinary.com/image/upload/t_recipe-256/mexican-breakfast-burrito-1365962.jpg>")
 
   ;; https://github.com/ztellman/aleph/issues/253
   @(-> (aleph.http/head "http://aleph.io/images/aleph.png")

--- a/src/oc/bot/language.clj
+++ b/src/oc/bot/language.clj
@@ -50,6 +50,12 @@
 
   (re-seq #"<(.*)>" "<https://threaded.martinklepsch.org/fav/apple-icon-152x152.png>")
 
+  (extract-url "<http://media.giphy.com/media/xTiTnlgsJTVPK9hGZa/giphy.gif>")
+
+  (downloadable-image? "<http://media.giphy.com/media/xTiTnlgsJTVPK9hGZa/giphy.gif>")
+
+  (downloadable-image? "<https://pbs.twimg.com/profile_images/700577267127193600/PtLt3m6R.png>")
+
   ;; https://github.com/ztellman/aleph/issues/253
   @(-> (aleph.http/head "http://aleph.io/images/aleph.png")
        (manifold.deferred/chain (fn [res] (prn res))))

--- a/src/oc/bot/language.clj
+++ b/src/oc/bot/language.clj
@@ -27,7 +27,7 @@
 
 (defn downloadable-image? [s]
   (when-let [url (extract-url s)]
-    @(-> (http/head url)
+    @(-> (http/get url)
          (d/chain (fn [res]
                     (when (and (= 200 (:status res))
                                ;; aleph sets "content-type" https://github.com/ztellman/aleph/blob/1427d8142b1762244645425dc6bee685feb15a95/src/aleph/http/client_middleware.clj#L282-L289

--- a/src/oc/bot/language.clj
+++ b/src/oc/bot/language.clj
@@ -1,6 +1,7 @@
 (ns oc.bot.language
   (:require [clojure.string :as string]
             [aleph.http :as http]
+            [taoensso.timbre :as timbre]
             [manifold.deferred :as d])
   (:import [org.apache.commons.validator UrlValidator]))
 
@@ -27,17 +28,35 @@
 (defn downloadable-image? [s]
   (when-let [url (extract-url s)]
     @(-> (http/head url)
-         (d/chain #(when (and (= 200 (:status %))
-                              (-> % :headers (get "content-type") image?))
-                     url))
-         (d/catch (fn [_] false))))) ; aleph sets "content-type" https://github.com/ztellman/aleph/blob/1427d8142b1762244645425dc6bee685feb15a95/src/aleph/http/client_middleware.clj#L282-L289
+         (d/chain (fn [res]
+                    (when (and (= 200 (:status res))
+                               ;; aleph sets "content-type" https://github.com/ztellman/aleph/blob/1427d8142b1762244645425dc6bee685feb15a95/src/aleph/http/client_middleware.clj#L282-L289
+                               (-> res :headers (get "content-type") image?))
+                      url)))
+         (d/catch (fn [e]
+                    (timbre/error e "The following URL caused an exception while checking" {:url url})
+                    false)))))
 
 (comment
-  (downloadable-image? "https://-R6qwnGcrHlY/AAAAAAAAAAI/AAAAAAAAAAA/SuoCUhq2DAM/w80-h80/photo.jpg")
+  (downloadable-image? "<https://-R6qwnGcrHlY/AAAAAAAAAAI/AAAAAAAAAAA/SuoCUhq2DAM/w80-h80/photo.jpg>")
+
+  (downloadable-image? "<http://aleph.io/images/aleph.png>")
+
+  (downloadable-image? "<https://logo.clearbit.com/pantheon.io?s=126>")
+
   (valid-url "https://-R6qwnGcrHlY/AAAAAAAAAAI/AAAAAAAAAAA/SuoCUhq2DAM/w80-h80/photo.jpg")
 
   (valid-url "<https://threaded.martinklepsch.org/fav/apple-icon-152x152.png>")
 
   (re-seq #"<(.*)>" "<https://threaded.martinklepsch.org/fav/apple-icon-152x152.png>")
+
+  ;; https://github.com/ztellman/aleph/issues/253
+  @(-> (aleph.http/head "http://aleph.io/images/aleph.png")
+       (manifold.deferred/chain (fn [res] (prn res))))
+
+  @(-> (aleph.http/get "http://aleph.io/images/aleph.png")
+       (manifold.deferred/chain (fn [res] (prn res))))
+
+
 
   )

--- a/src/oc/bot/language.clj
+++ b/src/oc/bot/language.clj
@@ -18,6 +18,8 @@
 
 (def no? #{"n" "no" "not yet"})
 
+(def not-now? #{"not now" "later"})
+
 (def euro? #{"€" "eur" "euro"})
 
 (def dollar? #{"$" "usd" "dollar"})

--- a/src/oc/bot/language.clj
+++ b/src/oc/bot/language.clj
@@ -7,11 +7,12 @@
 (defn image? [s]
   (string/starts-with? s "image"))
 
-(defn valid-url? [url-str]
-  (let [validator (UrlValidator.)]
-    (when (.isValid validator url-str) url-str)))
+(defn extract-url [url-str]
+  (let [s (second (first (re-seq #"<(.*)>" url-str)))
+        validator (UrlValidator.)]
+    (when (.isValid validator s) s)))
 
-;; ================================
+;; ==================================================================
 
 (def yes? #{"y" "yes"})
 
@@ -22,13 +23,19 @@
 (def dollar? #{"$" "usd" "dollar"})
 
 (defn downloadable-image? [s]
-  (when (valid-url? s)
-    @(-> (http/head s)
+  (when-let [url (extract-url s)]
+    @(-> (http/head url)
          (d/chain #(when (and (= 200 (:status %))
                               (-> % :headers (get "content-type") image?))
-                     s))
+                     url))
          (d/catch (fn [_] false))))) ; aleph sets "content-type" https://github.com/ztellman/aleph/blob/1427d8142b1762244645425dc6bee685feb15a95/src/aleph/http/client_middleware.clj#L282-L289
 
 (comment
   (downloadable-image? "https://-R6qwnGcrHlY/AAAAAAAAAAI/AAAAAAAAAAA/SuoCUhq2DAM/w80-h80/photo.jpg")
-  (valid-url? "https://-R6qwnGcrHlY/AAAAAAAAAAI/AAAAAAAAAAA/SuoCUhq2DAM/w80-h80/photo.jpg"))
+  (valid-url "https://-R6qwnGcrHlY/AAAAAAAAAAI/AAAAAAAAAAA/SuoCUhq2DAM/w80-h80/photo.jpg")
+
+  (valid-url "<https://threaded.martinklepsch.org/fav/apple-icon-152x152.png>")
+
+  (re-seq #"<(.*)>" "<https://threaded.martinklepsch.org/fav/apple-icon-152x152.png>")
+
+  )

--- a/src/oc/bot/language.clj
+++ b/src/oc/bot/language.clj
@@ -1,4 +1,17 @@
-(ns oc.bot.language)
+(ns oc.bot.language
+  (:require [clojure.string :as string]
+            [aleph.http :as http]
+            [manifold.deferred :as d])
+  (:import [org.apache.commons.validator UrlValidator]))
+
+(defn image? [s]
+  (string/starts-with? s "image"))
+
+(defn valid-url? [url-str]
+  (let [validator (UrlValidator.)]
+    (when (.isValid validator url-str) url-str)))
+
+;; ================================
 
 (def yes? #{"y" "yes"})
 
@@ -7,3 +20,15 @@
 (def euro? #{"€" "eur" "euro"})
 
 (def dollar? #{"$" "usd" "dollar"})
+
+(defn downloadable-image? [s]
+  (when (valid-url? s)
+    @(-> (http/head s)
+         (d/chain #(when (and (= 200 (:status %))
+                              (-> % :headers (get "content-type") image?))
+                     s))
+         (d/catch (fn [_] false))))) ; aleph sets "content-type" https://github.com/ztellman/aleph/blob/1427d8142b1762244645425dc6bee685feb15a95/src/aleph/http/client_middleware.clj#L282-L289
+
+(comment
+  (downloadable-image? "https://-R6qwnGcrHlY/AAAAAAAAAAI/AAAAAAAAAAA/SuoCUhq2DAM/w80-h80/photo.jpg")
+  (valid-url? "https://-R6qwnGcrHlY/AAAAAAAAAAI/AAAAAAAAAAA/SuoCUhq2DAM/w80-h80/photo.jpg"))

--- a/src/oc/bot/slack.clj
+++ b/src/oc/bot/slack.clj
@@ -25,7 +25,6 @@
 
 (defn parse [msg out]
   (let [m (chesire/parse-string msg keyword)]
-    (timbre/debug m)
     (when-not (get m :ok ::ok)
       (timbre/error "Error event from Slack" m))
     (s/put! out m)))

--- a/src/oc/bot/slack_api.clj
+++ b/src/oc/bot/slack_api.clj
@@ -1,0 +1,39 @@
+(ns oc.bot.slack-api
+  (:require [aleph.http :as http]
+            [manifold.deferred :as d]))
+
+;; (defn slack-btn-uri
+;;   "Generate a URI suitable for initializing OAuth flow"
+;;   []
+;;   (let [scopes (clojure.string/join "," (map name (e/env :slack-scopes)))]
+;;     (str "https://slack.com/oauth/authorize?scope=" scopes "&client_id=" (e/env :slack-client-id))))
+
+;; (def list-channels-action
+;;   "https://slack.com/api/channels.list")
+
+;; (defn get-channels
+;;   "Retrieve all channels for the team the given API token is associated with"
+;;   [api-token]
+;;   (let [response (-> @(http/get list-channels-action {:query-params {:token api-token} :as :json}) :body)]
+;;     (when (:ok response) (:channels response))))
+
+(defn slack-api [method params]
+  (-> (http/get (str "https://slack.com/api/" (name method))
+                {:query-params params :as :json})
+      (d/chain #(if (-> % :body :ok)
+                  %
+                  (throw (ex-info "Error after calling Slack API"
+                                  {:method method :params params
+                                   :response (select-keys % [:body :status])}))))))
+
+(defn get-users [token]
+  (-> @(slack-api :users.list {:token token}) :body :members))
+
+(defn get-team-info [token]
+  (-> @(slack-api :team.info {:token token}) :body :team))
+
+(defn get-im-channel [token user-id]
+  (-> @(slack-api :im.open {:token token :user user-id}) :body :channel :id))
+
+(defn get-websocket-url [token]
+  (-> @(slack-api :rtm.start {:token token}) :body :url))

--- a/src/oc/bot/sqs.clj
+++ b/src/oc/bot/sqs.clj
@@ -40,9 +40,9 @@
   "Check for a message and, if one is available, put it into the given deferrred"
   [queue-url deferred]
   (try
-    (timbre/debug "Checking for message in queue:" queue-url)
+    (timbre/trace "Checking for message in queue:" queue-url)
     (when-let [m (get-message queue-url)]
-      (timbre/debug "Got message from queue:" queue-url)
+      (timbre/info "Got message from queue:" queue-url)
       (d/success! deferred m))
     (catch Throwable e
       (timbre/error "Exception while polling SQS:" e)

--- a/test/oc/bot/fsm_test.clj
+++ b/test/oc/bot/fsm_test.clj
@@ -1,0 +1,33 @@
+(ns oc.bot.fsm-test
+  (:require [oc.bot.fsm :as fsm]
+            [automat.core :as a]
+            [clojure.test :as test :refer [is deftest testing]]))
+
+(defn machine [actions-atom]
+  (a/compile [(a/or [:a (a/$ :log)]
+                    [:b (a/$ :log) (a/or :b1 :b2)]
+                    [:c (a/$ :log) (a/+ :c1 :c2 :c3)])]
+             {:signal first
+              :reducers {:log (fsm/dry-run-wrap (fn [state input] (swap! actions-atom conj input) state))}}))
+
+(deftest possible-transitions-test
+  (let [fsm             (machine (atom []))
+        with-transition (fn [t] (fsm/possible-transitions fsm (a/advance fsm {} [t])))]
+    (is (= #{} (with-transition :a)))
+    (is (= #{:b1 :b2} (with-transition :b)))
+    (is (= #{:c1} (with-transition :c)))))
+
+(deftest dry-run-wrap-test
+  (let [actions    (atom [])
+        fsm        (machine actions)]
+    (a/advance fsm {::fsm/dry-run false} [:a])
+    (is (= [[:a]] @actions))
+    (a/advance fsm {::fsm/dry-run true} [:b])
+    (is (= [[:a]] @actions))
+    (a/advance fsm {::fsm/dry-run false} [:c])
+    (is (= [[:a] [:c]] @actions))))
+
+(comment
+  (test/run-tests) 
+
+  )


### PR DESCRIPTION
[trello card](https://trello.com/c/2sNLCroN/486-include-team-s-logo-from-slack-as-company-logo-in-new-company-creation-flow) & [trello card](https://trello.com/c/QTeRaScu/495-update-onboarding-script-to-update-logo-rather-than-name)

- The onboarding conversation now checks the company's logo instead of its name
- if a custom logo has been specified in Slack the user can confirm it or provide an alternative
- if no logo is specified the user may supply one

To Test:

- [x] sign in
- [x] create a company
- [x] go through the onboarding conversation initiated with the slack account who created the company
- [x] update the logo and try other permutations of the conversation
- [x] verify the logo has been updated in the database/web