### PR TITLE
Slack Digests

### DIFF
--- a/.lein-spell
+++ b/.lein-spell
@@ -1,0 +1,2 @@
+eastwood
+kibit

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2016-2017 OpenCompany, LLC.
+Copyright © 2016-2018 OpenCompany, LLC.
 
 Mozilla Public License, version 2.0
 

--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 
 Distributed under the [Mozilla Public License v2.0](http://www.mozilla.org/MPL/2.0/). See `LICENSE` for full text.
 
-Copyright © 2016-2017 OpenCompany, LLC.
+Copyright © 2016-2018 OpenCompany, LLC.

--- a/opt/samples/digests/apple.json
+++ b/opt/samples/digests/apple.json
@@ -1,0 +1,59 @@
+{
+  "digest-frequency": "weekly",
+  "org-slug": "apple",
+  "org-name": "Apple",
+  "logo-url": "https://www.apple.com/ac/structured-data/images/knowledge_graph_logo.png",
+  "logo-height": 302,
+  "logo-width": 302,
+  "boards": [
+    {
+      "name": "General",
+      "posts": [
+        {
+          "headline": "Introducing some new faces!",
+          "url": "http://localhost:3000/apple/general/post/e921-4f0c-9b9c",
+          "publisher" : {
+            "avatar-url" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-512.png",
+            "name" : "Lisa Malo",
+            "user-id" : "d6e9-4529-8e7b"
+          },
+          "published-at": "2017-11-5T17:00:48.729Z"
+        }, {
+          "headline": "We've hit 2,000 paid subscribers!",
+          "url": "http://localhost:3000/apple/general/post/e921-4f0c-9b9c",
+          "publisher" : {
+            "avatar-url" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-512.png",
+            "name" : "David Smith",
+            "user-id" : "d6e9-4529-8e7b"
+          },
+          "published-at": "2017-11-5T17:00:48.729Z"
+        }
+      ]
+    }, {
+      "name": "Design",
+      "slug": "design",
+      "uuid": "e921-4f0c-9b9c",
+      "posts": [
+        {
+          "headline": "Building Design Collaboration into our Workflow",
+          "url": "http://localhost:3000/apple/design/post/e921-4f0c-9b9c",
+          "publisher" : {
+            "avatar-url" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-512.png",
+            "name" : "Lisa Malo",
+            "user-id" : "d6e9-4529-8e7b"
+          },
+          "published-at": "2017-11-5T17:00:48.729Z"
+        }, {
+          "headline": "Versioning, Licensing and Sketch 4.0",
+          "url": "http://localhost:3000/apple/design/post/e921-4f0c-9b9c",
+          "publisher" : {
+            "avatar-url" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-512.png",
+            "name" : "David Smith",
+            "user-id" : "d6e9-4529-8e7b"
+          },
+          "published-at": "2017-11-5T17:00:48.729Z"
+        }
+      ]
+    }
+  ]
+}

--- a/opt/samples/digests/carrot.json
+++ b/opt/samples/digests/carrot.json
@@ -1,0 +1,59 @@
+{
+  "digest-frequency": "daily",
+  "org-slug": "carrot",
+  "org-name": "Carrot",
+  "logo-url": "https://slack-files2.s3-us-west-2.amazonaws.com/avatars/2017-09-16/243287999207_9e662352c5c6175b971a_230.png",
+  "logo-height": 230,
+  "logo-width": 230,
+  "boards": [
+    {
+      "name": "All-hands 🙌",
+      "posts": [
+        {
+          "headline": "Introducing some new faces!",
+          "url": "http://localhost:3000/carrot/all-hands/post/e921-4f0c-9b9c",
+          "publisher" : {
+            "avatar-url" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-512.png",
+            "name" : "Lisa Malo",
+            "user-id" : "d6e9-4529-8e7b"
+          },
+          "published-at": "2017-11-5T17:00:48.729Z"
+        }, {
+          "headline": "We've hit 2,000 paid subscribers!",
+          "url": "http://localhost:3000/carrot/all-hands/post/e921-4f0c-9b9c",
+          "publisher" : {
+            "avatar-url" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-512.png",
+            "name" : "David Smith",
+            "user-id" : "d6e9-4529-8e7b"
+          },
+          "published-at": "2017-11-5T17:00:48.729Z"
+        }
+      ]
+    }, {
+      "name": "Design",
+      "slug": "design",
+      "uuid": "e921-4f0c-9b9c",
+      "posts": [
+        {
+          "headline": "Building Design Collaboration into our Workflow",
+          "url": "http://localhost:3000/carrot/design/post/e921-4f0c-9b9c",
+          "publisher" : {
+            "avatar-url" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-512.png",
+            "name" : "Lisa Malo",
+            "user-id" : "d6e9-4529-8e7b"
+          },
+          "published-at": "2017-11-5T17:00:48.729Z"
+        }, {
+          "headline": "Versioning, Licensing and Sketch 4.0",
+          "url": "http://localhost:3000/carrot/design/post/e921-4f0c-9b9c",
+          "publisher" : {
+            "avatar-url" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-512.png",
+            "name" : "David Smith",
+            "user-id" : "d6e9-4529-8e7b"
+          },
+          "published-at": "2017-11-5T17:00:48.729Z"
+        }
+      ]
+    }
+  ]
+}

--- a/opt/samples/digests/no-logo.json
+++ b/opt/samples/digests/no-logo.json
@@ -1,0 +1,59 @@
+{
+  "digest-frequency": "weekly",
+  "org-slug": "apple",
+  "org-name": "Apple",
+  "logo-url": null,
+  "logo-height": null,
+  "logo-width": null,
+  "boards": [
+    {
+      "name": "General",
+      "posts": [
+        {
+          "headline": "Introducing some new faces!",
+          "url": "http://localhost:3000/apple/general/post/e921-4f0c-9b9c",
+          "publisher" : {
+            "avatar-url" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-512.png",
+            "name" : "Lisa Malo",
+            "user-id" : "d6e9-4529-8e7b"
+          },
+          "published-at": "2017-11-5T17:00:48.729Z"
+        }, {
+          "headline": "We've hit 2,000 paid subscribers!",
+          "url": "http://localhost:3000/apple/general/post/e921-4f0c-9b9c",
+          "publisher" : {
+            "avatar-url" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-512.png",
+            "name" : "David Smith",
+            "user-id" : "d6e9-4529-8e7b"
+          },
+          "published-at": "2017-11-5T17:00:48.729Z"
+        }
+      ]
+    }, {
+      "name": "Design",
+      "slug": "design",
+      "uuid": "e921-4f0c-9b9c",
+      "posts": [
+        {
+          "headline": "Building Design Collaboration into our Workflow",
+          "url": "http://localhost:3000/apple/design/post/e921-4f0c-9b9c",
+          "publisher" : {
+            "avatar-url" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-512.png",
+            "name" : "Lisa Malo",
+            "user-id" : "d6e9-4529-8e7b"
+          },
+          "published-at": "2017-11-5T17:00:48.729Z"
+        }, {
+          "headline": "Versioning, Licensing and Sketch 4.0",
+          "url": "http://localhost:3000/apple/design/post/e921-4f0c-9b9c",
+          "publisher" : {
+            "avatar-url" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-512.png",
+            "name" : "David Smith",
+            "user-id" : "d6e9-4529-8e7b"
+          },
+          "published-at": "2017-11-5T17:00:48.729Z"
+        }
+      ]
+    }
+  ]
+}

--- a/project.clj
+++ b/project.clj
@@ -18,15 +18,17 @@
     ;; String manipulation library https://github.com/funcool/cuerdas
     [funcool/cuerdas "2.0.4"] 
     ;; Asynch comm. for clojure (http-client) https://github.com/ztellman/aleph
-    [aleph "0.4.4"]
+    [aleph "0.4.5-alpha2"]
     ;; Async programming tools https://github.com/ztellman/manifold
     [manifold "0.1.7-alpha6"]
     ;; Namespace management https://github.com/clojure/tools.namespace
     ;; NB: org.clojure/tools.reader pulled in by oc.lib
     [org.clojure/tools.namespace "0.3.0-alpha4" :exclusions [org.clojure/tools.reader]] 
 
+    [clj-soup/clojure-soup "0.1.3"]
+
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.14.8"]
+    [open-company/lib "0.14.10"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; core.async - Async programming and communication https://github.com/clojure/core.async
     ;; Component - Component Lifecycle https://github.com/stuartsierra/component
@@ -74,7 +76,7 @@
         ;; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint
         [lein-pprint "1.2.0"]
         ;; Check for outdated dependencies https://github.com/xsc/lein-ancient
-        [lein-ancient "0.6.14"]
+        [lein-ancient "0.6.15"]
         ;; Catch spelling mistakes in docs and docstrings https://github.com/cldwalker/lein-spell
         [lein-spell "0.1.0"]
         ;; Dead code finder https://github.com/venantius/yagni
@@ -96,7 +98,10 @@
         (require '[aprint.core :refer (aprint ap)]
                  '[clojure.stacktrace :refer (print-stack-trace)]
                  '[clojure.string :as s]
-                 '[cheshire.core :as json])
+                 '[cheshire.core :as json]
+                 '[clj-time.core :as t]
+                 '[clj-time.coerce :as coerce]
+                 '[clj-time.format :as f])
       ]
     }]
 

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
     [clj-soup/clojure-soup "0.1.3"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.14.14"]
+    [open-company/lib "0.14.15"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; core.async - Async programming and communication https://github.com/clojure/core.async
     ;; Component - Component Lifecycle https://github.com/stuartsierra/component

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
     ;; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/clojure "1.9.0"]
     ;; String manipulation library https://github.com/funcool/cuerdas
-    [funcool/cuerdas "2.0.4"] 
+    [funcool/cuerdas "2.0.5"] 
     ;; Asynch comm. for clojure (http-client) https://github.com/ztellman/aleph
     [aleph "0.4.5-alpha2"]
     ;; Async programming tools https://github.com/ztellman/manifold
@@ -28,7 +28,7 @@
     [clj-soup/clojure-soup "0.1.3"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.14.10"]
+    [open-company/lib "0.14.14"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; core.async - Async programming and communication https://github.com/clojure/core.async
     ;; Component - Component Lifecycle https://github.com/stuartsierra/component

--- a/project.clj
+++ b/project.clj
@@ -18,13 +18,13 @@
     ;; String manipulation library https://github.com/funcool/cuerdas
     [funcool/cuerdas "2.0.5"] 
     ;; Asynch comm. for clojure (http-client) https://github.com/ztellman/aleph
-    [aleph "0.4.5-alpha2"]
+    [aleph "0.4.5-alpha3"]
     ;; Async programming tools https://github.com/ztellman/manifold
     [manifold "0.1.7-alpha6"]
     ;; Namespace management https://github.com/clojure/tools.namespace
     ;; NB: org.clojure/tools.reader pulled in by oc.lib
     [org.clojure/tools.namespace "0.3.0-alpha4" :exclusions [org.clojure/tools.reader]] 
-
+    ;; Clojure wrapper for jsoup HTML parser https://github.com/mfornos/clojure-soup
     [clj-soup/clojure-soup "0.1.3"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib

--- a/src/oc/bot/digest.clj
+++ b/src/oc/bot/digest.clj
@@ -10,15 +10,16 @@
 
 (defn- post-as-attachment [board-name {:keys [publisher url headline published-at]}]
   (let [author-name (:name publisher)
+        clean-headline (.text (soup/parse headline)) ; Strip out any HTML tags
         ts (-> published-at ; since Unix epoch timestamp for Slack
               (coerce/to-long)
               (/ 1000)
               (int))]
     {
-      :fallback (str "A post in " board-name " by " author-name ", '" headline "'.")
+      :fallback (str "A post in " board-name " by " author-name ", '" clean-headline "'.")
       :color "#FFF"
       :author_name author-name
-      :title (.text (soup/parse headline)) ; Strip out any HTML tags
+      :title clean-headline
       :title_link url
       ;:text "" ; use for comments
       :ts ts

--- a/src/oc/bot/digest.clj
+++ b/src/oc/bot/digest.clj
@@ -1,0 +1,41 @@
+(ns oc.bot.digest
+  "
+  Namespace to convert an OC digest request into a Slack message with an attachment per post,
+  and to send it via Slack.
+  "
+  (:require [taoensso.timbre :as timbre]
+            [clj-time.coerce :as coerce]
+            [oc.lib.slack :as slack]
+            [jsoup.soup :as soup]))
+
+(defn- post-as-attachment [board-name {:keys [publisher url headline published-at]}]
+  (let [author-name (:name publisher)
+        ts (-> published-at ; since Unix epoch timestamp for Slack
+              (coerce/to-long)
+              (/ 1000)
+              (int))]
+    {
+      :fallback (str "A post in " board-name " by " author-name ", '" headline "'.")
+      :color "#FFF"
+      :author_name author-name
+      :title (.text (soup/parse headline)) ; Strip out any HTML tags
+      :title_link url
+      ;:text "" ; use for comments
+      :ts ts
+    }))
+
+(defn- posts-for-board [board]
+  (let [pretext (:name board)
+        attachments (map #(post-as-attachment (:name board) %) (:posts board))]
+    (concat [(assoc (first attachments) :pretext pretext)] (rest attachments))))
+
+(defn send-digest [token {channel :id :as receiver} {:keys [digest-frequency org-name boards] :as msg}]
+  {:pre [(string? token)
+         (map? receiver)
+         (map? msg)]}
+    (let [frequency (if (= (keyword digest-frequency) :daily) "Daily" "Weekly")
+          intro (str "Your *" org-name "* " frequency " Digest")
+          attachments (flatten (map posts-for-board boards))]
+      (timbre/info "Sending digest to:" channel " with:" token)
+      (slack/post-message token channel intro)
+      (slack/post-attachments token channel attachments)))


### PR DESCRIPTION
https://trello.com/c/YBUH0SR6

This PR supports https://github.com/open-company/open-company-digest/pull/3

Allows the Slack bot to receive a new message type, `digest`, via SQS, and to generate a daily or weekly Slack digest for the user.

- [x] Review the code

To test:

- [x] Startup the digest service on this branch
- [x] Use the `digest` branch of web to set your user profile to daily Slack in an org that has a Slack bot
- [x] Add some content so there is something to digest, add some comments too
- [x] Initiate a daily digest request from the CLI (see https://github.com/open-company/open-company-digest)
- [x] Check your Slack for a daily digest, does it match the content you created? Good!
- [x] Switch your user to weekly digest in the web UI
- [x] Initiate a weekly digest request from the CLI
- [x] Check your Slack for a weekly digest, does it match the content you created? Good!
- [x] Merge
- [ ] Deploy to beta (this is backwards compatible w/ not having the rest of the Digest PRs deployed)
- [ ] Solve global warming