### PR TITLE
Private invite notification

### DIFF
--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -113,7 +113,7 @@
                     board-url (s/join "/" [c/web-url
                                            (:slug (:org msg))
                                            (:slug board)])
-                    message (str "You have been invited to a private board. "
+                    message (str "You've been invited to a private board: "
                                  "<" board-url "|" (:name board) ">" )
                     receiver (first (adjust-receiver
                                      {:receiver
@@ -205,6 +205,7 @@
                         (= (:notification-type msg-parsed) "add"))
                        (= (:resource-type msg-parsed) "board"))
                   (timbre/debug "private board notification!")
+                  (timbre/debug msg-parsed)
                   (send-private-board-notification msg-parsed)))
               (let [bot-token  (-> msg :bot :token)
                     _missing_token (if bot-token false (throw (ex-info "Message body missing bot token." {:msg-body msg})))]

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -7,6 +7,7 @@
             [com.stuartsierra.component :as component]
             [amazonica.aws.sqs :as aws-sqs]
             [taoensso.timbre :as timbre]
+            [cheshire.core :as json]
             [clj-time.format :as format]
             [raven-clj.core :as sentry]
             [raven-clj.interfaces :as sentry-interfaces]
@@ -77,19 +78,53 @@
       :else
       (throw (ex-info "Failed to adjust receiver" {:msg msg})))))
 
+(defn- read-message-body
+  "
+  Try to parse as json, otherwise use read-string.
+  "
+  [msg]
+  (try
+    (json/parse-string msg true)
+    (catch Exception e
+      (read-string msg))))
+
 (defn sqs-handler
   "Handle an incoming SQS message to the bot."
   [msg done-channel]
-  (let [msg-body (read-string (:body msg))
-        error (if (:test-error msg-body) (/ 1 0) false) ; a message testing Sentry error reporting
-        bot-token  (or (-> msg-body :bot :token) (slack-org/bot-token-for @db-pool (-> msg-body :receiver :slack-org-id)))
-        _missing_token (if bot-token false (throw (ex-info "Missing bot token for:" {:msg-body msg-body})))]
+  (let [msg-body (read-message-body (:body msg))
+        error (if (:test-error msg-body) (/ 1 0) false)] ; a message testing Sentry error reporting
     (timbre/infof "Received message from SQS: %s\n" msg-body)
-    (doseq [m (adjust-receiver msg-body)]
-      (>!! bot-chan (assoc-in m [:bot :token] bot-token)))) ; send the message to the bot's channel
+    (>!! bot-chan msg-body)) ; send the message to the bot's channel
   (sqs/ack done-channel msg))
 
 ;; ----- Bot Request handling -----
+
+(defn- send-private-board-notification [msg]
+  (let [notifications (:notifications (:content msg))
+        board (:new (:content msg))
+        user (:user msg)
+        slack-bots (:slack-bots user)]
+    (doseq [team (:teams user)]
+      (let [slack-bot (first ((keyword team) slack-bots))]
+        (doseq [notify notifications]
+          (let [slack-info (first (vals (:slack-users notify)))]
+            (when slack-info
+              (let [token (:token slack-bot)
+                    board-url (s/join "/" [c/web-url
+                                           (:slug (:org msg))
+                                           (:slug board)])
+                    message (str "You have been invited to a private board. "
+                                 "<" board-url "|" (:name board) ">" )
+                    receiver (first (adjust-receiver
+                                     {:receiver
+                                      {
+                                       :id (:id slack-info)
+                                       :type :user
+                                       }
+                                      :bot {:token token}}))]
+                (slack/post-message token
+                                    (:id (:receiver receiver))
+                                    message)))))))))
 
 (defn- share-entry [token receiver {:keys [org-slug org-logo-url board-name headline note
                                            publisher secure-uuid sharer auto-share] :as msg}]
@@ -157,12 +192,24 @@
   (reset! bot-go true)
   (async/go (while @bot-go
       (timbre/info "Waiting for message on bot channel...")
-      (let [m (<!! bot-chan)]
+      (let [msg (<!! bot-chan)]
         (timbre/trace "Processing message on bot channel...")
-        (if (:stop m)
+        (if (:stop msg)
           (do (reset! bot-go false) (timbre/info "Bot stopped."))
           (try
-            (bot-handler m)
+            (if (:Message msg) ;; data change SNS message
+              (let [msg-parsed (json/parse-string (:Message msg) true)]
+                (when (and
+                       (or
+                        (= (:notification-type msg-parsed) "update")
+                        (= (:notification-type msg-parsed) "add"))
+                       (= (:resource-type msg-parsed) "board"))
+                  (timbre/debug "private board notification!")
+                  (send-private-board-notification msg-parsed)))
+              (let [bot-token  (-> msg :bot :token)
+                    _missing_token (if bot-token false (throw (ex-info "Message body missing bot token." {:msg-body msg})))]
+                (doseq [m (adjust-receiver msg)]
+                  (bot-handler m))))
             (timbre/trace "Processing complete.")
             (catch Exception e
               (timbre/error e))))

--- a/src/oc/bot/config.clj
+++ b/src/oc/bot/config.clj
@@ -53,4 +53,5 @@
                             "*Here's what I do:*\n"
                             ">- I ensure all your team's comments from Carrot make it into Slack\n"
                             ">- I also make sure posts shared from Carrot make it to Slack\n"
+                            ">- I let you know when you've been invited to a private board\n" 
                             ">- And, I can send you a <" web-url "/profile|daily or weekly digest> of new posts from your team"))


### PR DESCRIPTION
See instructions here https://github.com/open-company/open-company-auth/pull/28

This PR will send the private board notifications via slack.

You will have to subscribe the bot SQS arn to the storage SNS arn.  This can be done in the aws console.  On the bot SQS queue you will have to add permissions for everybody to send it a message.
Select the SQS queue and at the bottom there will be a permissions tab. Click add permission and select SQS SendMessage and choose the wild card *.    Then in SNS make a subscription to the storage SNS.  You will need the arn for both the storage SNS and the SQS queue.

![screenshot](https://user-images.githubusercontent.com/55220/36482589-df4a5800-16e1-11e8-81b9-7e9c9abc69b1.png)
