### PR TITLE
Lookup bot token if missing.

### DIFF
--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -206,10 +206,10 @@
                   (timbre/debug "Received private board notification:")
                   (timbre/debug msg-parsed)
                   (send-private-board-notification msg-parsed)))
-              (let [bot-token  (-> msg :bot :token)
-                    _missing_token (if bot-token false (throw (ex-info "Message body missing bot token." {:msg-body msg})))]
+              (let [bot-token  (or (-> msg :bot :token) (slack-org/bot-token-for @db-pool (-> msg :receiver :slack-org-id)))
+                    _missing_token (if bot-token false (throw (ex-info "Missing bot token for:" {:msg-body msg})))]
                 (doseq [m (adjust-receiver msg)]
-                  (bot-handler m))))
+                  (bot-handler (assoc-in m [:bot :token] bot-token)))))
             (timbre/trace "Processing complete.")
             (catch Exception e
               (timbre/error e))))


### PR DESCRIPTION
https://sentry.io/opencompany/oc-beta-bot/issues/520422921/

This fixes the above sentry error and gets the bot usage working again.


To test you will have to follow the ngrok instructions here https://github.com/open-company/open-company-interaction#ngrok

When you get slack messages going to your local setup you should be able to message Carrot Local and receive the usage instructions.  

This is also on staging for testing.


To recreate the bug on beta:

- From within Slack , select the Carrot bot from the `Apps` menu on the left.  Send it a message (`hello`). 
- [ ] Does the sentry message occur?

- Now on staging  or your local setup send a message to the bot
- [ ] do you get the usage message?