### PR TITLE
reduce amount of body shown in slack share.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,11 +16,11 @@
     ;; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/clojure "1.9.0"]
     ;; String manipulation library https://github.com/funcool/cuerdas
-    [funcool/cuerdas "2.0.5"] 
+    [funcool/cuerdas "2.0.6"] 
     ;; Asynch comm. for clojure (http-client) https://github.com/ztellman/aleph
-    [aleph "0.4.5-alpha6"]
+    [aleph "0.4.7-alpha1"]
     ;; Async programming tools https://github.com/ztellman/manifold
-    [manifold "0.1.7-alpha6"]
+    [manifold "0.1.8"]
     ;; Namespace management https://github.com/clojure/tools.namespace
     ;; NB: org.clojure/tools.reader pulled in by oc.lib
     [org.clojure/tools.namespace "0.3.0-alpha4" :exclusions [org.clojure/tools.reader]] 
@@ -28,7 +28,7 @@
     [clj-soup/clojure-soup "0.1.3"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.6"]
+    [open-company/lib "0.16.10"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; core.async - Async programming and communication https://github.com/clojure/core.async
     ;; Component - Component Lifecycle https://github.com/stuartsierra/component
@@ -57,7 +57,7 @@
       }
       :plugins [
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.2.6"]
+        [jonase/eastwood "0.2.9"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit        
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure]]
       ]
@@ -86,7 +86,7 @@
         ;; Dead code finder https://github.com/venantius/yagni
         [venantius/yagni "0.1.4" :exclusions [org.clojure/clojure]]
         ;; Autotest https://github.com/jakemcc/lein-test-refresh
-        [com.jakemccrary/lein-test-refresh "0.22.0"]
+        [com.jakemccrary/lein-test-refresh "0.23.0"]
       ]  
     }]
 

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -175,10 +175,8 @@
               ;; Post automatically shared on publication
               (str "A new post from *" (:name publisher) "* in *" board-name "*")
               ;; Manual share
-              (if clean-note
-                (str share-attribution ": " clean-note)
-                (str share-attribution)))
-        footer (str "Posted in "
+              (str share-attribution))
+        footer (str org-name " | Posted in "
                     board-name
                     " by "
                     (:name publisher)
@@ -190,18 +188,16 @@
                       " comment "
                       " comments ")
                     )
-        attachments [{
-                      :author_name org-name
-                      :author_url org-logo-url
-                      :pretext text
-                      :title clean-headline
-                      :title_link update-url
-                      :text (if (< (count reduced-body) (count clean-body))
-                              (str reduced-body " ...")
-                              reduced-body)
-                      :footer footer
-                      :attachment_type "default"
-                      :color "good"}]]
+        attachment {:title clean-headline
+                    :title_link update-url
+                    :text (if (< (count reduced-body) (count clean-body))
+                            (str reduced-body " ...")
+                            reduced-body)
+                    :footer footer
+                    :color "#FA6452"}
+        attachments (if clean-note
+                        [{:pretext text :text clean-note} attachment]
+                        [(assoc attachment :pretext text)])] ; no optional note provided 
     (slack/post-attachments token channel attachments)))
 
 (defn- invite [token receiver {:keys [org-name from from-id first-name url note] :as msg}]

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -164,6 +164,10 @@
                          (clean-text (.text (soup/parse headline))))
         clean-body (when-not (s/blank? body)
                      (clean-text (.text (soup/parse body))))
+        reduced-body (clojure.string/join " "
+                       (filter not-empty
+                         (take 20 ;; 20 words is the average long sentence
+                           (clojure.string/split clean-body #" "))))
         update-markdown (if (s/blank? headline) update-url (str "<" update-url "|" clean-headline ">"))
         share-attribution (if (= (:name publisher) (:name sharer))
                             (str "*" (:name sharer) "* shared a post in *" board-name "*")
@@ -193,7 +197,9 @@
                       :pretext text
                       :title clean-headline
                       :title_link update-url
-                      :text clean-body
+                      :text (if (< (count reduced-body) (count clean-body))
+                              (str reduced-body " ...")
+                              reduced-body)
                       :footer footer
                       :attachment_type "default"
                       :color "good"}]]

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -168,17 +168,16 @@
                        (filter not-empty
                          (take 20 ;; 20 words is the average long sentence
                            (clojure.string/split clean-body #" "))))
-        update-markdown (if (s/blank? headline) update-url (str "<" update-url "|" clean-headline ">"))
         share-attribution (if (= (:name publisher) (:name sharer))
                             (str "*" (:name sharer) "* shared a post in *" board-name "*")
                             (str "*" (:name sharer) "* shared a post by *" (:name publisher) "* in *" board-name "*"))
         text (if auto-share
               ;; Post automatically shared on publication
-              (str "A new post from *" (:name publisher) "* in *" board-name "*: " update-markdown)
+              (str "A new post from *" (:name publisher) "* in *" board-name "*")
               ;; Manual share
               (if clean-note
-                (str share-attribution ": " clean-note " — " update-markdown)
-                (str share-attribution ": " update-markdown)))
+                (str share-attribution ": " clean-note)
+                (str share-attribution)))
         footer (str "Posted in "
                     board-name
                     " by "


### PR DESCRIPTION
This change reduces the content of the post to 20 words. I picked 20 since according to google the average long sentence is 20 words.

To test:

- Click the share icon
- Share to a slack channel
- [x]  Do you see the unfurled post and is the content reduced if it is over 20 words?
- [x]  For content less than 20 is it displayed normally?
- [x] Is there no title in the text of the Slack message, only in the attachment?
- [x] is the color bar now Carrot orange?

Share again, this time with a personal note
- [x] Everything look good? Design option "C"