### PR TITLE
Handle the empty body case

### DIFF
--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -181,8 +181,9 @@
         clean-note (when-not (s/blank? note) (str (clean-text note)))
         clean-headline (when-not (s/blank? headline)
                          (clean-text (.text (soup/parse headline))))
-        clean-body (when-not (s/blank? body)
-                     (clean-text (.text (soup/parse body))))
+        clean-body (if-not (s/blank? body)
+                     (clean-text (.text (soup/parse body)))
+                     "")
         reduced-body (clojure.string/join " "
                        (filter not-empty
                          (take 20 ;; 20 words is the average long sentence


### PR DESCRIPTION
We might want to prevent this but as of now you can submit a post without a body and the bot will error on auto share/ share.

This handles the empty case to avoid the exception.

To test:

- create a new post in a section that has auto share to slack configured.
- [x] without this change the bot will throw a null pointer exception
- [x] with this change the post will be shared to slack.