### PR TITLE
Show more

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -147,6 +147,21 @@
     "bikeshed!" ["bikeshed" "-v" "-m" "120"] ; code check with max line length warning of 120 characters
     "ancient" ["ancient" ":all" ":allow-qualified"] ; check for out of date dependencies
   }
+  ;; ----- Code check configuration -----
+
+  :eastwood {
+    ;; Disable some linters that are enabled by default
+    ;; contant-test - just seems mostly ill-advised, logical constants are useful in something like a `->cond`
+    ;; wrong-arity - unfortunate, but it's failing on 3/arity of sqs/send-message
+    ;; Enable some linters that are disabled by default
+    ;;:add-linters [:unused-namespaces :unused-private-vars] ; :unused-locals]
+
+    :config-files ["third-party-macros.clj"]
+
+    ;; Exclude testing namespaces
+    :tests-paths ["test"]
+    :exclude-namespaces [:test-paths]
+  }
 
   :main oc.bot.app
 )

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -216,20 +216,16 @@
                     :author_name (:name publisher)
                     :author_icon (:avatar-url publisher)
                     :footer footer
-                    :color "#FA6452"}
-
-        show-more {:fallback "Show full post"
-                   :title "Show full post"
-                   :callback_id (str board-slug ":" uuid) ;; need post uuid and board slug
-                   :color "#FA6452"
-                   :attachment_type "default"
-                   :actions [{:name "show more"
-                              :text "Show More"
-                              :type "button"
-                              :value "show_more"}]}
+                    :color "#FA6452"
+                    ;; need post uuid and board slug
+                    :callback_id (str board-slug ":" uuid)
+                    :actions [{:name "show more"
+                               :text "Show More"
+                               :type "button"
+                               :value "show_more"}]}
         attachments (if clean-note
-                        [{:pretext text :text clean-note} contentatt show-more]
-                        [(assoc contentatt :pretext text) show-more])] ; no optional note provided 
+                        [{:pretext text :text clean-note} contentatt]
+                        [(assoc contentatt :pretext text)])] ;; no optional note provided
     (slack/post-attachments token channel attachments)))
 
 (defn- invite [token receiver {:keys [org-name from from-id first-name url note] :as msg}]

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -170,6 +170,7 @@
                                            publisher
                                            published-at
                                            secure-uuid
+                                           uuid
                                            sharer
                                            auto-share
                                            must-see
@@ -209,7 +210,7 @@
                       " comment "
                       " comments ")
                     )
-        attachment {:title clean-headline
+        contentatt {:title clean-headline
                     :title_link update-url
                     :text (if (< (count reduced-body) (count clean-body))
                             (str reduced-body " ...")
@@ -218,9 +219,18 @@
                     :author_icon (:avatar-url publisher)
                     :footer footer
                     :color "#FA6452"}
+        show-more {:fallback "Show entire post"
+                   :title "Show entire post"
+                   :callback_id uuid ;; need actual uuid
+                   :color "#FA6452"
+                   :attachment_type "default"
+                   :actions [{:name "show more"
+                              :text "Show More"
+                              :type "button"
+                              :value "show_more"}]}
         attachments (if clean-note
-                        [{:pretext text :text clean-note} attachment]
-                        [(assoc attachment :pretext text)])] ; no optional note provided 
+                        [{:pretext text :text clean-note} contentatt show-more]
+                        [(assoc contentatt :pretext text) show-more])] ; no optional note provided 
     (slack/post-attachments token channel attachments)))
 
 (defn- invite [token receiver {:keys [org-name from from-id first-name url note] :as msg}]

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -182,7 +182,8 @@
          (map? msg)]}
   (timbre/info "Sending entry share to Slack channel:" receiver)
   (let [channel (:id receiver)
-        update-url (s/join "/" [c/web-url org-slug "post" secure-uuid])
+        ;; need board slug
+        update-url (s/join "/" [c/web-url org-slug board-slug "post" uuid])
         clean-note (when-not (s/blank? note) (str (clean-text note)))
         clean-headline (digest/post-headline headline must-see video-id)
         clean-body (if-not (s/blank? body)

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -217,8 +217,8 @@
                     :footer footer
                     :color "#FA6452"}
 
-        show-more {:fallback "Show entire post"
-                   :title "Show entire post"
+        show-more {:fallback "Show full post"
+                   :title "Show full post"
                    :callback_id (str board-slug ":" uuid) ;; need post uuid and board slug
                    :color "#FA6452"
                    :attachment_type "default"

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -163,6 +163,7 @@
 (defn- share-entry [token receiver {:keys [org-slug
                                            org-logo-url
                                            org-name
+                                           board-slug
                                            board-name
                                            headline
                                            note
@@ -222,7 +223,7 @@
                     :color "#FA6452"}
         show-more {:fallback "Show entire post"
                    :title "Show entire post"
-                   :callback_id uuid ;; need actual uuid
+                   :callback_id (str board-slug ":" uuid) ;; need post uuid and board slug
                    :color "#FA6452"
                    :attachment_type "default"
                    :actions [{:name "show more"

--- a/src/oc/bot/async/slack_action.clj
+++ b/src/oc/bot/async/slack_action.clj
@@ -9,6 +9,7 @@
             [taoensso.timbre :as timbre]
             [clj-http.client :as http]
             [cheshire.core :as json]
+            [jsoup.soup :as soup]
             [oc.bot.auth :as auth]
             [oc.bot.storage :as storage]
             [oc.bot.resources.slack-org :as slack-org]
@@ -91,13 +92,15 @@
         team (:team payload)
         channel (:channel payload)
         user (:user payload)
-        message (:message payload)]
+        message (:message payload)
+        content (:body post)
+        parsed-body (.text (soup/parse content))]
     (http/post response-url
                {:headers {"Content-type" "application/json"
                           "Authorization" (str "Bearer " bot-token)}
                 :body (json/encode {:response_type "ephemeral"
                                     :replace_original false
-                                    :text (:body post)})})))
+                                    :text parsed-body})})))
 ;; ----- Event handling -----
 
 (defn- show-more

--- a/src/oc/bot/async/slack_action.clj
+++ b/src/oc/bot/async/slack_action.clj
@@ -91,15 +91,20 @@
         trigger (:trigger_id payload)
         team (:team payload)
         channel (:channel payload)
+        ogmessage (:original_message payload)
         user (:user payload)
-        message (:message payload)
         content (:body post)
         parsed-body (.text (soup/parse content))]
+    (timbre/debug ogmessage)
+    (timbre/debug (:ts ogmessage))
     (http/post response-url
                {:headers {"Content-type" "application/json"
                           "Authorization" (str "Bearer " bot-token)}
                 :body (json/encode {:response_type "ephemeral"
                                     :replace_original false
+                                    ;;:thread_ts (str (:ts ogmessage))
+                                    :as_user true
+                                    :link_names true
                                     :text parsed-body})})))
 ;; ----- Event handling -----
 

--- a/src/oc/bot/async/sqs_change.clj
+++ b/src/oc/bot/async/sqs_change.clj
@@ -24,7 +24,7 @@
                                  :uuid lib-schema/UniqueID
                                  schema/Keyword schema/Any}
    }
-   :user (schema/maybe lib-schema/User) ; occassionaly we have a non-user updating an entry, such as the Ziggeo callback
+   :user (schema/maybe lib-schema/User)
    :notification-at lib-schema/ISO8601})
 
 (schema/defn ^:always-validate ->change-entry-trigger :- ChangeTrigger

--- a/src/oc/bot/async/sqs_change.clj
+++ b/src/oc/bot/async/sqs_change.clj
@@ -1,0 +1,52 @@
+(ns oc.bot.async.sqs-change
+  "Publish change service triggers to AWS SQS."
+  (:require [amazonica.aws.sqs :as sqs]
+            [taoensso.timbre :as timbre]
+            [schema.core :as schema]
+            [oc.lib.schema :as lib-schema]
+            [oc.lib.db.common :as db-common]
+            [oc.bot.config :as config]))
+
+
+(defn- notification-type? [notification-type] (#{:add :update :delete :nux :read} notification-type))
+
+(defn- resource-type? [resource-type] (#{:org :board :entry} resource-type))
+
+
+(def ChangeTrigger 
+  "All change service triggers have the following properties."
+  {
+   :notification-type (schema/pred notification-type?)
+   :resource-type (schema/pred resource-type?)
+   :board { :uuid lib-schema/UniqueID }
+   :content {
+     (schema/optional-key :new) {:read-at lib-schema/ISO8601
+                                 :uuid lib-schema/UniqueID
+                                 schema/Keyword schema/Any}
+   }
+   :user (schema/maybe lib-schema/User) ; occassionaly we have a non-user updating an entry, such as the Ziggeo callback
+   :notification-at lib-schema/ISO8601})
+
+(schema/defn ^:always-validate ->change-entry-trigger :- ChangeTrigger
+  "Given an entry, create the change trigger."
+  [post user]
+  {
+   :notification-type :read
+   :resource-type :entry
+   :board {:uuid (:board-uuid post)}
+   :content {:new (merge {:read-at (db-common/current-timestamp)} post)}
+   :user user
+   :notification-at (db-common/current-timestamp)
+   })
+
+(defn- send-trigger! [trigger]
+  (timbre/info "Change request to queue:" config/aws-sqs-change-queue)
+  (sqs/send-message
+   {:access-key config/aws-access-key-id
+    :secret-key config/aws-secret-access-key}
+   config/aws-sqs-change-queue
+   trigger)
+  (timbre/info "Request sent to:" config/aws-sqs-change-queue))
+
+(schema/defn ^:always-validate send-change-trigger! [trigger :- ChangeTrigger]
+  (send-trigger! trigger))

--- a/src/oc/bot/config.clj
+++ b/src/oc/bot/config.clj
@@ -2,11 +2,6 @@
   "Namespace for the configuration parameters."
   (:require [environ.core :refer (env)]))
 
-(defn- bool
-  "Handle the fact that we may have true/false strings, when we want booleans."
-  [val]
-  (boolean (Boolean/valueOf val)))
-
 ;; ----- System -----
 
 (defonce processors (.availableProcessors (Runtime/getRuntime)))

--- a/src/oc/bot/config.clj
+++ b/src/oc/bot/config.clj
@@ -48,6 +48,7 @@
 
 (defonce aws-sqs-bot-queue (env :aws-sqs-bot-queue)) ; in-bound requests / notifications to the bot
 (defonce aws-sqs-storage-queue (env :aws-sqs-storage-queue)) ; out-bound to the Storage service
+(defonce aws-sqs-change-queue (env :aws-sqs-change-queue)) ; out-bound to the Change service
 
 ;; ----- JWT -----
 

--- a/src/oc/bot/storage.clj
+++ b/src/oc/bot/storage.clj
@@ -63,26 +63,25 @@
   Given a token, team id, and a post id retreive the post information from the storage service.
   "
   [jwtoken team-ids board-slug post-id]
-  (if-let [body (get-data config/storage-server-url jwtoken)]
+  (if-let [body (get-data (str config/storage-server-url) jwtoken)]
     (do
       (timbre/debug "Storage slash data:" (-> body :collection :items))
       (let [orgs (-> body :collection :items)
             org (first (filter #(team-ids (:team-id %)) orgs))]
-        (timbre/debug (str config/storage-server-url
-                           "/orgs/"
-                           (:slug org)
-                           "/boards/"
-                           board-slug
-                           "/entries/"
-                           post-id))
         (if org
-          (get-data (str config/storage-server-url
-                         "/orgs/"
-                         (:slug org)
-                         "/boards/"
-                         board-slug
-                         "/entries/"
-                         post-id) jwtoken)
+          (let [org-data (get-data (str config/storage-server-url
+                                        "/orgs/"
+                                        (:slug org)) jwtoken)
+                data (get-data (str config/storage-server-url
+                                    "/orgs/"
+                                    (:slug org)
+                                    "/boards/"
+                                    board-slug
+                                    "/entries/"
+                                    post-id) jwtoken)]
+            (-> data
+                (assoc :org-uuid (:uuid org-data))
+                (assoc :org-slug (:slug org-data))))
           (do
             (timbre/warn "Unable to retrieve board data for:" team-ids "in:" body) 
             default-on-error))))

--- a/src/oc/bot/storage.clj
+++ b/src/oc/bot/storage.clj
@@ -57,3 +57,38 @@
     (do
       (timbre/warn "Unable to retrieve org data.") 
       default-on-error)))
+
+(defn post-data-for
+  "
+  Given a token, team id, and a post id retreive the post information from the storage service.
+  "
+  [jwtoken team-ids board-slug post-id]
+  (if-let [body (get-data config/storage-server-url jwtoken)]
+    (do
+      (timbre/debug "Storage slash data:" (-> body :collection :items))
+      (let [orgs (-> body :collection :items)
+            org (first (filter #(team-ids (:team-id %)) orgs))]
+        (timbre/debug (str config/storage-server-url
+                           "/orgs/"
+                           (:slug org)
+                           "/boards/"
+                           board-slug
+                           "/entries/"
+                           post-id))
+        (if org
+          (get-data (str config/storage-server-url
+                         "/orgs/"
+                         (:slug org)
+                         "/boards/"
+                         board-slug
+                         "/entries/"
+                         post-id) jwtoken)
+          (do
+            (timbre/warn "Unable to retrieve board data for:" team-ids "in:" body) 
+            default-on-error))))
+    (do
+      (timbre/warn "Unable to retrieve org data.") 
+      default-on-error)))
+
+
+  

--- a/third-party-macros.clj
+++ b/third-party-macros.clj
@@ -1,0 +1,6 @@
+(disable-warning
+ {:linter :wrong-arity
+  :function-symbol 'amazonica.aws.sqs/send-message
+  :arglists-for-linting
+  '([creds sqs-queue trigger])
+  :reason "defun creates calls to and with only 1 argument."})


### PR DESCRIPTION
This change adds a show more button to a shared slack message.  Clicking on the show more message will mark the post as read and send a slack ephemeral message to the user.

To test:

- share a post to a slack channel
- [ ] did the post show up in slack with a url in the title?
- [ ] did that url point to the private (logged in) url?
- [ ] is there a show more button with the slack messsage?
- [ ] does clicking the message send an ephemeral message to slack?

To test that the message was marked as read.
- as user 1 share a post to slack
- as user 2 login with slack and click show more
- [ ] did the ephemeral message get sent?  did the message get marked as read?
