### PR TITLE
Share subline tweaks

### DIFF
--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -198,18 +198,13 @@
               (str "A new post from *" (:name publisher) "* in *" board-name "*")
               ;; Manual share
               (str share-attribution))
-        footer (str org-name " | Posted in "
-                    board-name
-                    " by "
-                    (:name publisher)
-                    "  |  "
-                    (post-date published-at)
-                    "  |  "
-                    comment-count
-                    (if (= "1" comment-count)
-                      " comment "
-                      " comments ")
-                    )
+        footer (when-not auto-share
+                 (str (post-date published-at)
+                  "  |  "
+                  comment-count
+                  (if (= "1" comment-count)
+                    " comment "
+                    " comments ")))
         attachment {:title clean-headline
                     :title_link update-url
                     :text (if (< (count reduced-body) (count clean-body))


### PR DESCRIPTION
Card: https://trello.com/c/1aXeS4PB

Remove org, author and section in the footer for all shares. Keep date and comments count only for manual shares, remove the whole footer for autoshare (no need of date or comments since they are obvious).

To test:
- set a section to autoshare
- add a post
- [x] do you NOT see a footer in the autoshare? Good
- now share manually to the same channel
- [x] do you see date and comments count? Good