### PR TITLE
Send post title in slack notification.

### DIFF
--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -144,9 +144,9 @@
                         (str " from *" from "*"))
                       " ")
         intro (if mention?
-                (str "You were mentioned in a " (if comment? "comment" "post") attribution ":")
-                (str "You have a new comment" attribution " on your post: "))]
-    (str intro " <" entry-url "|" (if comment? "on the post: " " ") title ">")))
+                (str "You were mentioned in a " (if comment? "comment" "post") attribution (when comment? "on the post ") ":")
+                (str "You have a new comment " attribution " on your post: "))]
+    (str intro " <" entry-url "|" title ">")))
 
 (defn- send-private-board-notification [msg]
   (let [notifications (-> msg :content :notifications)

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -145,8 +145,8 @@
                       " ")
         intro (if mention?
                 (str "You were mentioned in a " (if comment? "comment" "post") attribution ":")
-                (str "You have a new comment" attribution " on your post:"))]
-    (str intro " <" entry-url "|" (if comment? "Comment on: " "Post: ") title ">")))
+                (str "You have a new comment" attribution " on your post: "))]
+    (str intro " <" entry-url "|" (if comment? "on the post: " " ") title ">")))
 
 (defn- send-private-board-notification [msg]
   (let [notifications (-> msg :content :notifications)

--- a/src/oc/bot/storage.clj
+++ b/src/oc/bot/storage.clj
@@ -57,3 +57,34 @@
     (do
       (timbre/warn "Unable to retrieve org data.") 
       default-on-error)))
+
+(defn post-data-for
+  "
+  Given a token, team id, and a post id retreive the post information from the storage service.
+  "
+  [jwtoken team-ids board-slug post-id]
+  (if-let [body (get-data (str config/storage-server-url) jwtoken)]
+    (do
+      (timbre/debug "Storage slash data:" (-> body :collection :items))
+      (let [orgs (-> body :collection :items)
+            org (first (filter #(team-ids (:team-id %)) orgs))]
+        (if org
+          (let [org-data (get-data (str config/storage-server-url
+                                        "/orgs/"
+                                        (:slug org)) jwtoken)
+                data (get-data (str config/storage-server-url
+                                    "/orgs/"
+                                    (:slug org)
+                                    "/boards/"
+                                    board-slug
+                                    "/entries/"
+                                    post-id) jwtoken)]
+            (-> data
+                (assoc :org-uuid (:uuid org-data))
+                (assoc :org-slug (:slug org-data))))
+          (do
+            (timbre/warn "Unable to retrieve board data for:" team-ids "in:" body)
+            default-on-error))))
+    (do
+      (timbre/warn "Unable to retrieve org data.")
+      default-on-error)))


### PR DESCRIPTION
Requires https://github.com/open-company/open-company-notify/pull/3

Sends the post title in a slack notification for mentions

To test:
- create a post with an @ mention to a slack user
- [x] does the user receive a message in slack and does it have the post's title?

- comment on the same post and @ mention the same slack user
- [x] does the slack message contain the title of the post?