### PR TITLE
Notification mention data

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
     [clj-http "3.9.1"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.19"]
+    [open-company/lib "0.16.23alpha"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; core.async - Async programming and communication https://github.com/clojure/core.async

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -276,10 +276,8 @@
         text-for-notification (text-for-notification msg)]
     (slack/post-attachments token
                             (:id receiver)
-                            [{:fallback (str text-for-notification
-                                             " \n" content)
-                              :text content
-                              :pretext text-for-notification}])))
+                            [{:text content}]
+                            text-for-notification)))
 
 (defn- bot-handler [msg]
   {:pre [(or (string? (:type msg)) (keyword? (:type msg)))

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -272,7 +272,9 @@
          (map? receiver)
          (map? msg)]}
   (timbre/info "Sending notification to Slack channel:" receiver)
-  (slack/post-message token (:id receiver) (text-for-notification msg)))
+  (let [content (.text (soup/parse (:content (:notification msg))))]
+    (slack/post-attachments token (:id receiver) [{:text content
+                                                   :pretext (text-for-notification msg)}])))
 
 (defn- bot-handler [msg]
   {:pre [(or (string? (:type msg)) (keyword? (:type msg)))

--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -144,7 +144,7 @@
                         (str " from *" from "*"))
                       " ")
         intro (if mention?
-                (str "You were mentioned in a " (if comment? "comment" "post") attribution (when comment? "on the post ") ":")
+                (str "You were mentioned in a " (if comment? "comment" "post") attribution (when comment? " on the post") ":")
                 (str "You have a new comment " attribution " on your post: "))]
     (str intro " <" entry-url "|" title ">")))
 
@@ -272,9 +272,14 @@
          (map? receiver)
          (map? msg)]}
   (timbre/info "Sending notification to Slack channel:" receiver)
-  (let [content (.text (soup/parse (:content (:notification msg))))]
-    (slack/post-attachments token (:id receiver) [{:text content
-                                                   :pretext (text-for-notification msg)}])))
+  (let [content (.text (soup/parse (:content (:notification msg))))
+        text-for-notification (text-for-notification msg)]
+    (slack/post-attachments token
+                            (:id receiver)
+                            [{:fallback (str text-for-notification
+                                             " \n" content)
+                              :text content
+                              :pretext text-for-notification}])))
 
 (defn- bot-handler [msg]
   {:pre [(or (string? (:type msg)) (keyword? (:type msg)))


### PR DESCRIPTION
Adds the context (information around the mention) to the slack notification.

Requires https://github.com/open-company/open-company-lib/pull/42

To test:

- set your notifications to slack
- with another user mention your test user in a comment
- [x] does that user get a notification with the context?

- with another user mention your test user in a post
- [x] does that user get a notification with the context?
