### PR TITLE
150 words on slack share

### DIFF
--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -188,7 +188,7 @@
                      "")
         reduced-body (clojure.string/join " "
                        (filter not-empty
-                         (take 20 ;; 20 words is the average long sentence
+                         (take 150 ;; 150 words is the average paragraph
                            (clojure.string/split clean-body #" "))))
         share-attribution (if (= (:name publisher) (:name sharer))
                             (str "*" (:name sharer) "* shared a post in *" board-name "*")


### PR DESCRIPTION
To test:

- share a post with more than 150 words
- [x] Does slack show 150 words?