### PR TITLE
Fix notification board

### DIFF
--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -60,15 +60,15 @@
 
 (defn get-post-data [payload]
 
-  (let [board-uuid (:board-id payload)
-        notification (:notification payload)
+  (let [notification (:notification payload)
+        board-uuid (:board-id notification)
         team (:team-id (:org payload))
         slack-bot (:bot payload)
         token (:token slack-bot)
         user-token (auth/user-token (:slack-user-id (:receiver payload)) (:slack-org-id slack-bot))
         teams (set [team])
         board-list (storage/board-list-for teams user-token)
-        board (first (filter #(= board-uuid (:board-uuid %)) board-list))]
+        board (first (filter #(= board-uuid (:uuid %)) board-list))]
     (storage/post-data-for user-token teams (:slug board) (:entry-id notification))))
 
 ;; ----- SQS handling -----

--- a/src/oc/bot/storage.clj
+++ b/src/oc/bot/storage.clj
@@ -33,7 +33,7 @@
 (defn- board-list [data]
   (timbre/debug "Storage org data:" (:boards data))
   (->> (:boards data)
-    (map #(select-keys % [:name :slug]))
+    (map #(select-keys % [:name :slug :uuid]))
     (remove #(= (:slug %) "drafts"))
     vec))
 


### PR DESCRIPTION
Bug: right now the wrong board is picked when loading the post data from storage for a notification.

To test:
- add a comment with a mention of your slack user to 3 posts from different boards
- [ ] did you get all? Good
