### PR TITLE
Limit to 20 words when sharing in slack.

### DIFF
--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -226,7 +226,7 @@
                      "")
         reduced-body (clojure.string/join " "
                        (filter not-empty
-                         (take 150 ;; 150 words is the average paragraph
+                         (take 20 ;; 20 words is the average sentence
                            (clojure.string/split clean-body #" "))))
         share-attribution (if (= (:name publisher) (:name sharer))
                             (str "*" (:name sharer) "* shared a post in *" board-name "*")


### PR DESCRIPTION
To test:

- create a post with more than one sentence.
- either manually share or post in an autoshare channel.
- [x] when shared to slack does only 20 words show up before the '...'?