### PR TITLE
Split payload

### DIFF
--- a/src/oc/bot/digest.clj
+++ b/src/oc/bot/digest.clj
@@ -61,7 +61,7 @@
   [attachments]
   (let [bytes (.getBytes (json/generate-string attachments) "UTF-8")
         byte-count (count bytes)
-        byte-limit 10000] ;; 16k is the limit but need to account for HTTP
+        byte-limit 6000] ;; 16k is the limit but need to account for HTTP
     (timbre/info "Slack limit?: " byte-count byte-limit)
     (if (> byte-count byte-limit)
       (let [parts-num (quot (count attachments)

--- a/src/oc/bot/digest.clj
+++ b/src/oc/bot/digest.clj
@@ -62,6 +62,7 @@
   (let [bytes (.getBytes (json/generate-string attachments) "UTF-8")
         byte-count (count bytes)
         byte-limit 10000] ;; 16k is the limit but need to account for HTTP
+    (timbre/info "Slack limit?: " byte-count byte-limit)
     (if (> byte-count byte-limit)
       (let [parts-num (quot (count attachments)
                             (inc (quot byte-count byte-limit)))


### PR DESCRIPTION
Handle the payload too large errors.

To test:
- create a lot of posts for the digest
- run the slack digest
- [x] without this change the slack API request returns a 413
- [x] with this change it splits the payload and sends multiple messages.