### PR TITLE
Update readme with S3 bucket naming fix and notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ An [AWS S3 bucket](https://aws.amazon.com/s3/) is used to cache Slack banner ima
 
 Another AWS S3 bucket is used to store the 6 footer image varients.
 
-_**Note on bucket naming:** the bot service will look for a bucket named "YOUR-BUCKET-v2",
-where `YOUR-BUCKET` is the name that you've configured for both `:digest-banner-s3-bucket` and
-`:digset-footer-s3-bucket`. So, make sure that when you create the bucket in S3 that you append
-"-v2" to its name._
+_**Note on bucket naming:** the bot service will look for a bucket named "{YOUR-BUCKET}-{VERSION}",
+where `{YOUR-BUCKET}` is the name that you've configured for both `:digest-banner-s3-bucket` and
+`:digset-footer-s3-bucket` and `{VERSION}` is the [currently configured (hard-coded) version string][1].
+So, make sure that when you create the bucket in S3 that you append `{VERSION}` to its name, or
+you'll receive "bucket not found" exceptions when trying to start the service._
 
 An API key is needed for [Filestack](https://www.filestack.com/) to build URL's that do image processing.
 
@@ -142,3 +143,5 @@ Copyright © 2016-2019 OpenCompany, LLC.
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [GNU Affero General Public License](https://www.gnu.org/licenses/agpl-3.0.en.html) for more details.
+
+[1]: https://github.com/open-company/open-company-bot/blob/74e5327601e9781555af9c127f5a64e32820672e/src/oc/bot/config.clj#L51-L55

--- a/README.md
+++ b/README.md
@@ -67,9 +67,16 @@ lein deps
 
 An [AWS SQS queue](https://aws.amazon.com/sqs/) is used to pass messages to the Bot. Setup an SQS Queue and key/secret access to the queue using the AWS Web Console or API.
 
-An [AWS S3 bucket](https://aws.amazon.com/s3/) is used to cache Slack banner images for the Bot. Setup an S3 bucket using the AWS Web Console or API with access of "Objects can be public".
+An [AWS S3 bucket](https://aws.amazon.com/s3/) is used to cache Slack banner images for the Bot.
 
-Another AWS S3 bucket is used to store the 6 footer image varients.
+Another AWS S3 bucket is used to store the 6 footer image variants. You will need to upload the
+[footer image folders][2] to this bucket manually via the S3 console.
+
+For both buckets, make sure the image objects are publicly accessible from the web. This is
+preferably done by selecting the object in the S3 console, going to the `Permissions` tab,
+and then checking the `Everyone` box under `Public access`. For local development, it's
+fine to just make the bucket itself public, but know that this is not acceptable in production,
+as it allows anyone to list the contents of the bucket.
 
 **Note on bucket naming:** the bot service will look for a bucket named `{YOUR-BUCKET}-{VERSION}`,
 where `{YOUR-BUCKET}` is the name that you've configured for `:digest-banner-s3-bucket` or
@@ -146,3 +153,4 @@ This program is free software: you can redistribute it and/or modify it under th
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [GNU Affero General Public License](https://www.gnu.org/licenses/agpl-3.0.en.html) for more details.
 
 [1]: https://github.com/open-company/open-company-bot/blob/74e5327601e9781555af9c127f5a64e32820672e/src/oc/bot/config.clj#L51-L55
+[2]: ./src/oc/assets/img/footer/v2

--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ An [AWS S3 bucket](https://aws.amazon.com/s3/) is used to cache Slack banner ima
 
 Another AWS S3 bucket is used to store the 6 footer image varients.
 
-_**Note on bucket naming:** the bot service will look for a bucket named "{YOUR-BUCKET}-{VERSION}",
-where `{YOUR-BUCKET}` is the name that you've configured for both `:digest-banner-s3-bucket` and
-`:digset-footer-s3-bucket` and `{VERSION}` is the [currently configured (hard-coded) version string][1].
-So, make sure that when you create the bucket in S3 that you append `{VERSION}` to its name, or
-you'll receive "bucket not found" exceptions when trying to start the service._
+_**Note on bucket naming:** the bot service will look for a bucket named `{YOUR-BUCKET}-{VERSION}`,
+where `{YOUR-BUCKET}` is the name that you've configured for `:digest-banner-s3-bucket` and
+`:digset-footer-s3-bucket` respectively, and `{VERSION}` is the [currently configured (hard-coded)
+version string][1].So, make sure that when you create the bucket in S3 that you append `{VERSION}`
+to its name, or you'll receive "bucket not found" exceptions when trying to start the service.
+Check the [config][1] file to obtain the current version strings._
 
 An API key is needed for [Filestack](https://www.filestack.com/) to build URL's that do image processing.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [OpenCompany](https://github.com/open-company) Bot 
+# [OpenCompany](https://github.com/open-company) Bot
 
 [![AGPL License](http://img.shields.io/badge/license-AGPL-blue.svg?style=flat)](https://www.gnu.org/licenses/agpl-3.0.en.html)
 [![Build Status](https://travis-ci.org/open-company/open-company-bot.svg?branch=master)](https://travis-ci.org/open-company/open-company-bot)
@@ -71,6 +71,11 @@ An [AWS S3 bucket](https://aws.amazon.com/s3/) is used to cache Slack banner ima
 
 Another AWS S3 bucket is used to store the 6 footer image varients.
 
+_**Note on bucket naming:** the bot service will look for a bucket named "YOUR-BUCKET-v2",
+where `YOUR-BUCKET` is the name that you've configured for both `:digest-banner-s3-bucket` and
+`:digset-footer-s3-bucket`. So, make sure that when you create the bucket in S3 that you append
+"-v2" to its name._
+
 An API key is needed for [Filestack](https://www.filestack.com/) to build URL's that do image processing.
 
 Before running anything make sure you adjust the values in the config map.
@@ -83,8 +88,8 @@ Before running anything make sure you adjust the values in the config map.
     :aws-secret-access-key "CHANGE-ME"
     :aws-sqs-bot-queue "CHANGE-ME" ; SQS queue to read inbound notifications/requests
     :aws-sqs-storage-queue "CHANGE-ME" ; SQS queue to send requests to the Storage service
-    :aws-s3-digest-banner-bucket "CHANGE-ME" ; S3 bucket for caching digest banners
-    :aws-s3-digest-footer-bucket "CHANGE-ME" ; S3 bucket for storing/serving digest footers
+    :digest-banner-s3-bucket "CHANGE-ME" ; S3 bucket for caching digest banners
+    :digest-footer-s3-bucket "CHANGE-ME" ; S3 bucket for storing/serving digest footers
     :filestack-api-key "CHANGE-ME"
     :log-level "debug"
 }

--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ An [AWS S3 bucket](https://aws.amazon.com/s3/) is used to cache Slack banner ima
 
 Another AWS S3 bucket is used to store the 6 footer image varients.
 
-_**Note on bucket naming:** the bot service will look for a bucket named `{YOUR-BUCKET}-{VERSION}`,
-where `{YOUR-BUCKET}` is the name that you've configured for `:digest-banner-s3-bucket` and
-`:digset-footer-s3-bucket` respectively, and `{VERSION}` is the [currently configured (hard-coded)
-version string][1].So, make sure that when you create the bucket in S3 that you append `{VERSION}`
-to its name, or you'll receive "bucket not found" exceptions when trying to start the service.
-Check the [config][1] file to obtain the current version strings._
+**Note on bucket naming:** the bot service will look for a bucket named `{YOUR-BUCKET}-{VERSION}`,
+where `{YOUR-BUCKET}` is the name that you've configured for `:digest-banner-s3-bucket` or
+`:digset-footer-s3-bucket` respectively, and `{VERSION}` is the [currently configured
+version string][1] (e.g. "v2"). So, make sure that when you create the bucket in S3 that you append
+`{VERSION}` to its name, or you'll receive "bucket not found" exceptions when trying to start the service.
+Check the [config][1] file to obtain the current version strings. For example: `my-banner-bucket-v2`.
 
 An API key is needed for [Filestack](https://www.filestack.com/) to build URL's that do image processing.
 


### PR DESCRIPTION
I was running into "bucket not found" errors while setting this service up locally, and noticed that the keywords used in `config.clj` are actually different than what's noted in the readme. 

I've updated the readme, and renamed my buckets in S3, only to run into "access denied" errors. Turning off all public access blocks (S3 -> click a bucket -> permissions tab -> public access settings -> uncheck all boxes) seems to have fixed the issue, but I'm not sure if this is the intended approach...**Please advise**.

Trello card: https://trello.com/c/TdaMbhHv/2016-fix-readme-inaccuracies-in-bot-service-repository