### PR TITLE
Improve the way Slack digest messages are "chunked"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,6 @@ pom.xml.asc
 .ruby-gemset
 .ruby-version
 
+.eastwood
+
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_script:
   - "echo $JAVA_OPTS"
   - lein clean
 script:
+- lein midje
 - lein eastwood
 - lein kibit
 branches:

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
     [manifold "0.1.9-alpha3"]
     ;; Namespace management https://github.com/clojure/tools.namespace
     ;; NB: org.clojure/tools.reader pulled in by oc.lib
-    [org.clojure/tools.namespace "0.3.0-alpha4" :exclusions [org.clojure/tools.reader]] 
+    [org.clojure/tools.namespace "0.3.0-alpha4" :exclusions [org.clojure/tools.reader]]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
     [open-company/lib "0.17.5"]
@@ -56,12 +56,21 @@
       :env {
         :db-name "open_company_auth_qa"
       }
+      :dependencies [
+        ;; Example-based testing https://github.com/marick/Midje
+        ;; NB: clj-time is pulled in by oc.lib
+        ;; NB: joda-time is pulled in by oc.lib via clj-time
+        ;; NB: commons-codec pulled in by oc.lib
+        [midje "1.9.8" :exclusions [joda-time clj-time commons-codec]]
+        ]
       :plugins [
         ;; Linter https://github.com/jonase/eastwood
         [jonase/eastwood "0.3.5"]
-        ;; Static code search for non-idiomatic code https://github.com/jonase/kibit        
+        ;; Test framework https://github.com/marick/Midje
+        [lein-midje "3.2.1"]
+        ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure]]
-      ]
+        ]
     }
 
     ;; Dev environment and dependencies
@@ -81,7 +90,7 @@
       :plugins [
         ;; Check for code smells https://github.com/dakrone/lein-bikeshed
         ;; NB: org.clojure/tools.cli is pulled in by lein-kibit
-        [lein-bikeshed "0.5.2" :exclusions [org.clojure/tools.cli]] 
+        [lein-bikeshed "0.5.2" :exclusions [org.clojure/tools.cli]]
         ;; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall
         [lein-checkall "0.1.1"]
         ;; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint
@@ -94,7 +103,7 @@
         [venantius/yagni "0.1.7" :exclusions [org.clojure/clojure]]
         ;; Autotest https://github.com/jakemcc/lein-test-refresh
         [com.jakemccrary/lein-test-refresh "0.24.1"]
-      ]  
+      ]
     }]
 
     :repl-config [:dev {
@@ -124,7 +133,7 @@
       :env {
         :db-name "open_company_auth"
         :env "production"
-      }      
+      }
     }
 
     :uberjar {
@@ -153,7 +162,7 @@
 
   :eastwood {
     ;; Disable some linters that are enabled by default
-    ;; contant-test - just seems mostly ill-advised, logical constants are useful in something like a `->cond` 
+    ;; contant-test - just seems mostly ill-advised, logical constants are useful in something like a `->cond`
     ;; wrong-arity - unfortunate, but it's failing on 3/arity of sqs/send-message
     ;; implicit-dependencies - uhh, just seems dumb
     :exclude-linters [:constant-test :wrong-arity :implicit-dependencies]

--- a/project.clj
+++ b/project.clj
@@ -14,17 +14,17 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.1-beta1"]
+    [org.clojure/clojure "1.10.1"]
     ;; Asynch comm. for clojure (http-client) https://github.com/ztellman/aleph
     [aleph "0.4.7-alpha5"]
     ;; Async programming tools https://github.com/ztellman/manifold
     [manifold "0.1.9-alpha3"]
     ;; Namespace management https://github.com/clojure/tools.namespace
     ;; NB: org.clojure/tools.reader pulled in by oc.lib
-    [org.clojure/tools.namespace "0.3.0-alpha4" :exclusions [org.clojure/tools.reader]]
+    [org.clojure/tools.namespace "0.3.0" :exclusions [org.clojure/tools.reader]]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.17.5"]
+    [open-company/lib "0.17.11"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; core.async - Async programming and communication https://github.com/clojure/core.async

--- a/src/oc/bot/digest.clj
+++ b/src/oc/bot/digest.clj
@@ -58,7 +58,8 @@
         author-name (:name publisher)
         clean-headline (post-headline headline)
         reduced-body (text/truncated-body body)
-        accessory-image (html/first-body-thumbnail body)
+        accessory-image (:thumbnail (html/first-body-thumbnail body))
+        has-accessory-image? (not-empty accessory-image)
         ;; if read/seen use seen attachment, else use button
         seen-this? (some #(= (:user-id msg) (:user-id %))
                       (get-in seen-data [:post :read]))
@@ -82,11 +83,11 @@
                     :text {
                       :type "mrkdwn"
                       :text (markdown-post url clean-headline reduced-body)}}
-        body-with-thumbnail (if accessory-image
+        body-with-thumbnail (if has-accessory-image?
                              (merge body-block
                               {:accessory {
                                 :type "image"
-                                :image_url (:thumbnail accessory-image)
+                                :image_url accessory-image
                                 :alt_text "Thumbnail"}})
                              body-block)
         interaction-block (when (or (pos? (or comment-count 0))

--- a/src/oc/bot/digest.clj
+++ b/src/oc/bot/digest.clj
@@ -112,7 +112,8 @@
 (defn- build-slack-digest-messages
   "
   Given a banner-block, a footer-block, and a sequence of post-chunks, returns a sequence of messages
-  where each message is ready to pass to the slack/post-blocks function.
+  where each message is ready to pass to the slack/post-blocks function. When given 0 post-chunks
+  returns nil.
   Here, chunk is defined as a sequence of blocks. While a post-chunk is considered one logical unit, it
   is composed of multiple blocks in order to achieve stylized display in Slack.
   Parition rules are as follows:
@@ -128,12 +129,11 @@
         middle-post-chunks           (->> post-chunks (drop 1) (butlast))
         header-post-chunk            (into [banner-block] (first post-chunks))
         footer-post-chunk            (conj (vec (last post-chunks)) footer-block)]
-    (if (>= num-post-chunks 2)
-      (concat [header-post-chunk]
-              middle-post-chunks
-              [footer-post-chunk])
-      (concat [banner-block] (flatten post-chunks) [footer-block])
-      )))
+    (when (pos? num-post-chunks)
+      (if (= num-post-chunks 1)
+        [[banner-block (ffirst post-chunks) footer-block]]
+        (concat [header-post-chunk] middle-post-chunks [footer-post-chunk])
+        ))))
 
 (defn- posts-with-board-name [board]
   (let [board-name (:name board)]

--- a/src/oc/bot/digest.clj
+++ b/src/oc/bot/digest.clj
@@ -52,7 +52,7 @@
 (defn- markdown-post [url headline body]
   (str "<" url "|*" (slack-escaped-text headline) "*>\n" (slack-escaped-text body)))
 
-(defn- post-as-block [{:keys [publisher url headline published-at comment-count comment-authors board-name
+(defn- post-as-chunk [{:keys [publisher url headline published-at comment-count comment-authors board-name
                               interaction-attribution must-see video-id body uuid reactions]} msg]
   (let [seen-data (get-seen-data msg uuid)
         author-name (:name publisher)
@@ -110,36 +110,31 @@
       post-block
       separator-block])))
 
-(defn- sort-must-see-board-name [a b]
-  (let [must-see (compare (:must-see a) (:must-see b))]
-    (if (zero? must-see)
-      (let [board-name (compare (:board-name a) (:board-name b))]
-        (if (zero? board-name)
-          (compare (:published-at a) (:published-at b))
-          board-name))
-      must-see)))
-
-(defn- split-blocks
-  "Split message blocks into multiple message if over 16kb
-   https://api.slack.com/docs/rate-limits"
-  [blocks]
-  (let [default-split 5 ; 4 posts plus header
-        four-split (partition default-split default-split nil blocks)
-        four-bytes (.getBytes (json/generate-string (first four-split) "UTF-8"))
-        four-count (count four-bytes)
-        bytes (.getBytes (json/generate-string blocks) "UTF-8")
-        byte-count (count bytes)
-        byte-limit 6000] ; 16k is the limit but need to account for HTTP
-    (timbre/info "Slack limit?: " four-count byte-count byte-limit)
-    (if (> four-count byte-limit)
-      (let [parts-num (quot (count blocks)
-                            (inc (quot byte-count byte-limit)))
-            split-num (if (> default-split parts-num)
-                          default-split
-                          parts-num)
-            parts (partition split-num split-num nil blocks)]
-        {:intro (first parts) :rest (rest parts)})
-      {:intro (first four-split) :rest (rest four-split)})))
+(defn- build-slack-digest-messages
+  "
+  Given a banner-block, a footer-block, and a sequence of post-chunks, returns a sequence of messages
+  where each message is ready to pass to the slack/post-blocks function.
+  Here, chunk is defined as a sequence of blocks. While a post-chunk is considered one logical unit, it
+  is composed of multiple blocks in order to achieve stylized display in Slack.
+  Parition rules are as follows:
+  - If there's just 1 post:  all in 1 message
+  - If there's just 2 posts: banner and 1st post as 1 message, 2nd post and footer as 1 message
+  - if there's 3 posts:      banner and 1st post as 1 message, 2nd post as a message, 3rd post and footer as 1 message
+  - if there's 4+ posts:     banner and 1st post as 1 message, each middle post as a message, last post and footer as 1 message
+  With these partition rules the badge count that is displayed in Slack will match the post count
+  in Carrot (i.e. banner and footer blocks have no effect on badge count).
+  "
+  [banner-block post-chunks footer-block]
+  (let [num-post-chunks              (count post-chunks)
+        middle-post-chunks           (->> post-chunks (drop 1) (butlast))
+        header-post-chunk            (into [banner-block] (first post-chunks))
+        footer-post-chunk            (conj (vec (last post-chunks)) footer-block)]
+    (if (>= num-post-chunks 2)
+      (concat [header-post-chunk]
+              middle-post-chunks
+              [footer-post-chunk])
+      (concat [banner-block] (flatten post-chunks) [footer-block])
+      )))
 
 (defn- posts-with-board-name [board]
   (let [board-name (:name board)]
@@ -149,45 +144,38 @@
   {:pre [(string? token)
          (map? receiver)
          (map? msg)]}
-  (let [intro (str ":coffee: Good morning " (or org-name "Carrot"))
-        banner-block {:type "image"
-                      :image_url (image/slack-banner-url org-slug logo-url)
-                      :alt_text org-name
-                      :title {
-                        :type "plain_text"
-                        :emoji true
-                        :text org-name}}
+  (let [intro            (str ":coffee: Good morning " (or org-name "Carrot"))
+        banner-block     {:type      "image"
+                          :image_url (image/slack-banner-url org-slug logo-url)
+                          :alt_text  org-name
+                          :title     {
+                                      :type  "plain_text"
+                                      :emoji true
+                                      :text  org-name}}
         footer-selection (inc (rand-int 6)) ; 1 through 6
-        footer-block {:type "image"
-                      :image_url (image/slack-footer-url footer-selection)
-                      :alt_text "The end"
-                      :title {
-                       :type "plain_text"
-                       :text "The end"}}
+        footer-block     {:type      "image"
+                          :image_url (image/slack-footer-url footer-selection)
+                          :alt_text  "The end"
+                          :title     {
+                                      :type "plain_text"
+                                      :text "The end"}}
 
-        boards (map posts-with-board-name (:boards msg))
-        all-posts (mapcat :posts boards)
-        sorted-posts (sort sort-must-see-board-name all-posts)
-        must-see (filter :must-see sorted-posts)
-        non-must-see (filter (comp not :must-see) sorted-posts)
-        must-see-blocks (flatten (map #(post-as-block % msg) must-see))
-        regular-blocks (flatten (map #(post-as-block % msg) non-must-see))
-        ;; Remove the last divider
-        all-posts-blocks (butlast (concat must-see-blocks regular-blocks))
-        all-blocks (concat [banner-block]
-                            all-posts-blocks
-                            [footer-block])
-        split-blocks (split-blocks all-blocks)]
-    (timbre/debug "All blocks count:" (count all-blocks))
-    (timbre/debug "Split blocks:" split-blocks)
+        boards          (map posts-with-board-name (:boards msg))
+        all-posts       (mapcat :posts boards)
+        sorted-posts    (sort-by (juxt :must-see :board-name :published-at) all-posts)
+        must-see        (filter :must-see sorted-posts)
+        non-must-see    (filter (comp not :must-see) sorted-posts)
+        must-see-chunks (mapv #(post-as-chunk % msg) must-see)
+        regular-chunks  (mapv #(post-as-chunk % msg) non-must-see)
+        regular-chunks* (update regular-chunks (-> regular-chunks count dec) butlast) ;; remove the last divider
+        all-chunks      (concat must-see-chunks regular-chunks*)
+        digest-messages (build-slack-digest-messages banner-block
+                                                     all-chunks
+                                                     footer-block)
+        ]
+    (timbre/debug "Banner attachment:" banner-block)
+    (timbre/debug "Chunk count:" (count all-chunks))
     (timbre/debug "Footer attachment:" footer-block)
     (timbre/info "Sending digest to:" channel " with:" token)
-    (if (:intro split-blocks)
-      (do
-        (slack/post-blocks token
-                           channel
-                           (:intro split-blocks)
-                           intro)
-        (doseq [part (:rest split-blocks)]
-          (slack/post-blocks token channel part)))
-      (slack/post-blocks token channel (:rest split-blocks) intro))))
+    (doseq [msg digest-messages]
+      (slack/post-blocks token channel msg intro))))

--- a/src/oc/bot/digest.clj
+++ b/src/oc/bot/digest.clj
@@ -3,7 +3,6 @@
   Namespace to convert an OC digest request into a Slack message with an attachment per post, and to send it via Slack.
   "
   (:require [taoensso.timbre :as timbre]
-            [cheshire.core :as json]
             [jsoup.soup :as soup]
             [oc.lib.text :as text]
             [oc.lib.html :as html]

--- a/src/oc/bot/digest.clj
+++ b/src/oc/bot/digest.clj
@@ -128,10 +128,10 @@
   (let [num-post-chunks              (count post-chunks)
         middle-post-chunks           (->> post-chunks (drop 1) (butlast))
         header-post-chunk            (into [banner-block] (first post-chunks))
-        footer-post-chunk            (conj (vec (last post-chunks)) footer-block)]
+        footer-post-chunk            (-> post-chunks last vec (conj footer-block))]
     (when (pos? num-post-chunks)
       (if (= num-post-chunks 1)
-        [[banner-block (ffirst post-chunks) footer-block]]
+        (vector (conj header-post-chunk footer-block))
         (concat [header-post-chunk] middle-post-chunks [footer-post-chunk])
         ))))
 

--- a/test/oc/bot/unit/digest.clj
+++ b/test/oc/bot/unit/digest.clj
@@ -7,38 +7,47 @@
 
 (def banner-block {:block "banner"})
 (def footer-block {:block "footer"})
+(def post-block   {:block "post"})
+(def acc-block    {:block "accessory"})
 
 (defn- mock-post-chunks
+  "Returns n mocked post chunks, each containing 2 example blocks."
   [n]
-  (repeat n [{:block "post"}]))
+  (repeat n [post-block acc-block]))
 
 (facts "regarding bot digest generation"
   (fact "zero posts results in nil (no slack messages)"
     (build-slack-digest-messages banner-block (mock-post-chunks 0) footer-block)
     =>
     nil)
+
   (fact "a single post results in a single message"
     (build-slack-digest-messages banner-block (mock-post-chunks 1) footer-block)
     =>
-    [[banner-block {:block "post"} footer-block]])
+    [[banner-block post-block acc-block footer-block]])
+
   (fact "two posts results in 2 messages, 1 coupled with the banner, 1 coupled with the footer"
     (build-slack-digest-messages banner-block (mock-post-chunks 2) footer-block)
     =>
-    [[banner-block {:block "post"}] [{:block "post"} footer-block]])
+    [[banner-block post-block acc-block] [post-block acc-block footer-block]])
+
   (fact "N posts, where N>=2, results in N messages"
     (build-slack-digest-messages banner-block (mock-post-chunks 3) footer-block)
     =>
-    [[banner-block {:block "post"}] [{:block "post"}] [{:block "post"} footer-block]]
+    [[banner-block post-block acc-block] [post-block acc-block] [post-block acc-block footer-block]]
     ;; -------
     (build-slack-digest-messages banner-block (mock-post-chunks 4) footer-block)
     =>
-    [[banner-block {:block "post"}] [{:block "post"}] [{:block "post"}] [{:block "post"} footer-block]]
+    [[banner-block post-block acc-block]
+     [post-block acc-block]
+     [post-block acc-block]
+     [post-block acc-block footer-block]]
     ;; -------
     (build-slack-digest-messages banner-block (mock-post-chunks 5) footer-block)
     =>
-    [[banner-block {:block "post"}]
-     [{:block "post"}]
-     [{:block "post"}]
-     [{:block "post"}]
-     [{:block "post"} footer-block]]
+    [[banner-block post-block acc-block]
+     [post-block acc-block]
+     [post-block acc-block]
+     [post-block acc-block]
+     [post-block acc-block footer-block]]
     ))

--- a/test/oc/bot/unit/digest.clj
+++ b/test/oc/bot/unit/digest.clj
@@ -1,0 +1,44 @@
+(ns oc.bot.unit.digest
+  (:require [midje.sweet :refer :all]
+            [oc.bot.digest :as sut]))
+
+(def build-slack-digest-messages
+  #'oc.bot.digest/build-slack-digest-messages)
+
+(def banner-block {:block "banner"})
+(def footer-block {:block "footer"})
+
+(defn- mock-post-chunks
+  [n]
+  (repeat n [{:block "post"}]))
+
+(facts "regarding bot digest generation"
+  (fact "zero posts results in nil (no slack messages)"
+    (build-slack-digest-messages banner-block (mock-post-chunks 0) footer-block)
+    =>
+    nil)
+  (fact "a single post results in a single message"
+    (build-slack-digest-messages banner-block (mock-post-chunks 1) footer-block)
+    =>
+    [[banner-block {:block "post"} footer-block]])
+  (fact "two posts results in 2 messages, 1 coupled with the banner, 1 coupled with the footer"
+    (build-slack-digest-messages banner-block (mock-post-chunks 2) footer-block)
+    =>
+    [[banner-block {:block "post"}] [{:block "post"} footer-block]])
+  (fact "N posts, where N>=2, results in N messages"
+    (build-slack-digest-messages banner-block (mock-post-chunks 3) footer-block)
+    =>
+    [[banner-block {:block "post"}] [{:block "post"}] [{:block "post"} footer-block]]
+    ;; -------
+    (build-slack-digest-messages banner-block (mock-post-chunks 4) footer-block)
+    =>
+    [[banner-block {:block "post"}] [{:block "post"}] [{:block "post"}] [{:block "post"} footer-block]]
+    ;; -------
+    (build-slack-digest-messages banner-block (mock-post-chunks 5) footer-block)
+    =>
+    [[banner-block {:block "post"}]
+     [{:block "post"}]
+     [{:block "post"}]
+     [{:block "post"}]
+     [{:block "post"} footer-block]]
+    ))


### PR DESCRIPTION
Note that this PR encapsulates _both_ of the following Trello cards.

Card: https://trello.com/c/PXMgjBzh/1994-change-how-slack-digest-messages-are-chunked

Relevant sentry exception fixed in this PR: https://sentry.io/organizations/opencompany/issues/981121572/?project=81593&query=is%3Aunresolved

To test:

1. Clear out your local databases (rethink and dynamo) and restart services
2. Onboard owner user via slack (org 1)
3. **Delete sample messages**. We need to test the case of 0 digest messages.
4. Enable the slack bot
5. Invite an email address that you own via email onboard (we will test email digest for regressions shortly)
6. Onboard member user via slack (org 1)
7. In the browser housing your owner user's session, visit the [run slack digest][1] link to force a digest run. Check slack/logs to **make sure that no messages are sent**.
8. Perform the same test in your member user's browser session.
9. Create a regular post (not must-see) using either member, rerun the slack digest, and observe that the digest in slack **contains only 1 message** with banner, post, and footer block all in one message (it's helpful to select a different channel in Slack before running the digest so that you can observe the notification badge count).
10. Create a must-see post using either member, rerun the slack digest, and observe that the digest in slack **contains 2 messages**, and that the "must see" post is above the first post (i.e. sorted by priority).
11. Create a third regular post (not must-see) with either member **in a different board**, rerun the slack digest, and observe that the digest **contains 3 separate messages**, and that this new post is sorted alphabetically by board name (but still below the must-see post).
12. Create a fourth regular post (non must-see) with either member **in the same board as the last test**, rerun the slack digest, and observe that the digest **contains 4 messages**, and that this new post is sorted below the last post (i.e. sorted by time)
13. In your member user's browser session, tab away from Carrot so that posts are not viewed on FoC. Create a few posts with your owner user, and then run the member user's digest. Ensure that "you have viewed this post" **is not preset** on the new posts you just made. If you're testing in a Carrot 2.0 environment (you should!) then do the exact opposite of this test (i.e. mark posts as read).
14. Onboard the user that you invited via email in a different browser session, and [run their email digest][2]. Ensure that you receive the email digest, and that it is properly formatted/sorted (nothing in this PR should affect the email digest, so this is a regression test).

[1]: http://localhost:3008/_/slack/run
[2]: http://localhost:3008/_/email/run