### PR TITLE
Fix OutOfBounds exception occurring in edge case of bot digest

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
     [org.clojure/tools.namespace "0.3.0" :exclusions [org.clojure/tools.reader]]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.17.11"]
+    [open-company/lib "0.17.12"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; Aleph - Asynch comm. for clojure (http-client) https://github.com/ztellman/aleph
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun

--- a/src/oc/bot/digest.clj
+++ b/src/oc/bot/digest.clj
@@ -176,10 +176,13 @@
         non-must-see    (filter (comp not :must-see) sorted-posts)
         must-see-chunks (mapv #(post-as-chunk % msg) must-see)
         regular-chunks  (mapv #(post-as-chunk % msg) non-must-see)
-        regular-chunks* (update regular-chunks (-> regular-chunks count dec) butlast) ;; remove the last divider
-        all-chunks      (concat must-see-chunks regular-chunks*)
+        all-chunks      (concat must-see-chunks regular-chunks)
+        all-chunks*     (if-let [last-chunk (last all-chunks)]
+                          (conj (-> all-chunks butlast vec)
+                                (butlast last-chunk)) ;; remove the last section divider
+                          all-chunks)
         digest-messages (build-slack-digest-messages banner-block
-                                                     all-chunks
+                                                     all-chunks*
                                                      footer-block)
         ]
     (timbre/debug "Banner attachment:" banner-block)


### PR DESCRIPTION
This PR is a fix for the [java.lang.IndexOutOfBoundsException errors brought to light by Sentry](https://sentry.io/organizations/opencompany/issues/1072058782/events/).

The original PR that introduced this regression: https://github.com/open-company/open-company-bot/pull/81

Root cause: digest building was using `update` to modify the last element of a vector by its `count`, opening the potential for OOB exceptions. Further, this `update` was misplaced, in that it was only occurring for non-must-see posts, when the correct solution must perform this `update` on _all_ concatenated posts.

To test:
- You'll need 2 users: one Slack, and one of any type for authoring posts. Make sure the Slack bot is enabled.
- Put your local system into a state in which your test users' digests are empty (i.e. your test users should have zero unread posts)
- [x] Trigger a slack digest, does this result in nothing posted to Slack?
- With author user, create a single must-see post.
- [x] Trigger slack, does this result in a digest with a single must-see post in Slack? (This was the edge case causing the exception)
- With author user, create a *non* must-see post
- [x] Trigger slack, do you see both posts in Slack, must-see post sorted first?
- Delete the must-see post
- [x] Trigger slack, only the *non* must-see post is visible in Slack digest?

This PR does not affect email digests, but you care to sanity test those as well.