### PR TITLE
HTML not getting scrubbed from rich abstract going to Slack

### DIFF
--- a/src/oc/bot/async/bot.clj
+++ b/src/oc/bot/async/bot.clj
@@ -220,7 +220,7 @@
   (let [channel (:id receiver)
         update-url (s/join "/" [c/web-url org-slug board-slug "post" entry-uuid])
         clean-note (text/clean-html note)
-        clean-headline (digest/post-headline headline)
+        clean-headline (text/clean-html headline)
         clean-body (text/clean-html body)
         clean-abstract (text/clean-html abstract)
         reduced-body (lib-text/truncated-body clean-body)

--- a/src/oc/bot/digest.clj
+++ b/src/oc/bot/digest.clj
@@ -6,7 +6,6 @@
             [clj-time.core :as t]
             [clj-time.format :as f]
             [taoensso.timbre :as timbre]
-            [jsoup.soup :as soup]
             [oc.lib.text :as lib-text]
             [oc.lib.html :as html]
             [oc.lib.slack :as slack]

--- a/src/oc/bot/digest.clj
+++ b/src/oc/bot/digest.clj
@@ -2,21 +2,19 @@
   "
   Namespace to convert an OC digest request into a Slack message with an attachment per post, and to send it via Slack.
   "
-  (:require [taoensso.timbre :as timbre]
+  (:require [clojure.string :as s]
+            [clj-time.core :as t]
+            [clj-time.format :as f]
+            [taoensso.timbre :as timbre]
             [jsoup.soup :as soup]
-            [oc.lib.text :as text]
+            [oc.lib.text :as lib-text]
             [oc.lib.html :as html]
             [oc.lib.slack :as slack]
             [oc.lib.user :as user-avatar]
             [oc.bot.config :as c]
-            [clojure.string :as s]
-            [clj-time.core :as t]
-            [clj-time.format :as f]))
+            [oc.bot.lib.text :as text]))
 
 (def date-format (f/formatter "MMMM d, YYYY"))
-
-(defn post-headline [headline]
-  (.text (soup/parse headline)))
 
 (defn- board-access-string [board-access]
   (cond
@@ -31,12 +29,14 @@
                               board-name board-access interaction-attribution must-see video-id body uuid
                               reactions follow-up]} msg]
   (let [author-name (:name publisher)
-        clean-headline (post-headline headline)
+        clean-headline (text/clean-html headline)
+        clean-body (text/clean-html body)
+        clean-abstract (text/clean-html abstract)
         headline-with-tag (cond
                             follow-up (str clean-headline " [Follow-up]")
                             must-see (str clean-headline " [Must See]")
                             :else clean-headline)
-        reduced-body (if (s/blank? abstract) (text/truncated-body body) abstract)
+        reduced-body (if (s/blank? clean-abstract) (lib-text/truncated-body clean-body) clean-abstract)
         accessory-image (:thumbnail (html/first-body-thumbnail body))
         has-accessory-image? (not-empty accessory-image)
         btn-attach [{:type "button"

--- a/src/oc/bot/lib/text.clj
+++ b/src/oc/bot/lib/text.clj
@@ -1,0 +1,15 @@
+(ns oc.bot.lib.text
+  (:require [clojure.string :as s]
+            [cuerdas.core :as str]
+            [jsoup.soup :as soup]))
+
+(defn- clean-text [text]
+  (-> text
+    (s/replace #"&nbsp;" " ")
+    (str/strip-tags)
+    (str/strip-newlines)))
+
+(defn clean-html [text]
+  (if-not (s/blank? text)
+    (clean-text (.text (soup/parse text)))
+    ""))


### PR DESCRIPTION
[Trello](https://trello.com/c/Gaec5oZN)

Fixes an issue brought about by making the abstract field editable with the MediumEditor. It now contains HTML and it was getting sent raw to Slack.

This change cleans the HTML from the abstract just like we do/did from the body. It also has some refactoring to better share this code.

To test:

- Have a Slack enabled org with the Bot installed, 2 users, at least one of which is a Slack user with notification preferences set to Slack
- Create a section that is set to auto-share to Slack
- Create a new post with no abstract and a long body.
- [x] Is the body there in the auto-share, truncated, with no HTML? Nice.
- Send your Slack user a Slack digest (`http://localhost:3008/_/slack/run`)
- [x] Is the body there in the digest, truncated, with no HTML? Great.
- Create a new post with a "fancy" abstract of bold text, italic text and link(s)
- [x] Is the abstract plain text in the auto-share with no HTML? Perfect.
- Send your Slack user a Slack digest (`http://localhost:3008/_/slack/run`)
- [x] Is the abstract plain text in the digest with no HTML? Wonderful.
- [ ] Deploy
- [x] Dance like no one is watching